### PR TITLE
Add SSE event replay on EventSource reconnect

### DIFF
--- a/drizzle/migrations/0002_research_steps_event_column.sql
+++ b/drizzle/migrations/0002_research_steps_event_column.sql
@@ -1,0 +1,6 @@
+-- Slice 5: store the full encoded AgentEvent JSON per step row, so SSE
+-- replay on EventSource reconnect can re-emit the original event with
+-- the same id + type + payload. The default `{}` keeps the constraint
+-- satisfied for any pre-existing rows from earlier slices; new rows
+-- always supply a real value via `appendStep`.
+ALTER TABLE `research_steps` ADD `event` text DEFAULT '{}' NOT NULL;

--- a/drizzle/migrations/meta/0002_snapshot.json
+++ b/drizzle/migrations/meta/0002_snapshot.json
@@ -1,0 +1,471 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "b0518cf6-15e2-4c1f-b29f-2a46c7d77e84",
+  "prevId": "a88c3995-b65b-46fa-a104-fa28cae34a0f",
+  "tables": {
+    "prd_sections": {
+      "name": "prd_sections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text(40)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "section": {
+          "name": "section",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "prd_sections_session_section_uq": {
+          "name": "prd_sections_session_section_uq",
+          "columns": [
+            "session_id",
+            "section"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "prd_sections_session_id_research_sessions_id_fk": {
+          "name": "prd_sections_session_id_research_sessions_id_fk",
+          "tableFrom": "prd_sections",
+          "tableTo": "research_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "research_glossary": {
+      "name": "research_glossary",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text(40)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "term": {
+          "name": "term",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "definition": {
+          "name": "definition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avoid_terms": {
+          "name": "avoid_terms",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "research_glossary_session_id_research_sessions_id_fk": {
+          "name": "research_glossary_session_id_research_sessions_id_fk",
+          "tableFrom": "research_glossary",
+          "tableTo": "research_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "research_open_qs": {
+      "name": "research_open_qs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text(40)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "research_open_qs_session_id_research_sessions_id_fk": {
+          "name": "research_open_qs_session_id_research_sessions_id_fk",
+          "tableFrom": "research_open_qs",
+          "tableTo": "research_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "research_questions": {
+      "name": "research_questions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text(40)",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text(40)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "step_id": {
+          "name": "step_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recommended_answer": {
+          "name": "recommended_answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_reply": {
+          "name": "user_reply",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "asked_at": {
+          "name": "asked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "answered_at": {
+          "name": "answered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "research_questions_session_id_research_sessions_id_fk": {
+          "name": "research_questions_session_id_research_sessions_id_fk",
+          "tableFrom": "research_questions",
+          "tableTo": "research_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "research_questions_step_id_research_steps_id_fk": {
+          "name": "research_questions_step_id_research_steps_id_fk",
+          "tableFrom": "research_questions",
+          "tableTo": "research_steps",
+          "columnsFrom": [
+            "step_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "research_sessions": {
+      "name": "research_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text(40)",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "initial_prompt": {
+          "name": "initial_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "research_steps": {
+      "name": "research_steps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text(40)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "step_number": {
+          "name": "step_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "llm_prompt": {
+          "name": "llm_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "llm_response": {
+          "name": "llm_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_request": {
+          "name": "tool_request",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_response": {
+          "name": "tool_response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text(7)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "research_steps_session_id_research_sessions_id_fk": {
+          "name": "research_steps_session_id_research_sessions_id_fk",
+          "tableFrom": "research_steps",
+          "tableTo": "research_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1777753441490,
       "tag": "0001_prd_sections_unique_section",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1777779807852,
+      "tag": "0002_research_steps_event_column",
+      "breakpoints": true
     }
   ]
 }

--- a/src/do/research.ts
+++ b/src/do/research.ts
@@ -33,14 +33,11 @@ import {
   SchemaViolation,
   statusForError,
 } from '~/shared/domain/errors'
-import { runLoop } from '~/shared/agent/loop'
 import { makeCatalog, SessionContext } from '~/shared/agent/tools/catalog'
 import { builtinTools } from '~/shared/agent/tools/builtin'
+import { sessionEventStream } from '~/shared/research/replay'
 import { ResearchRepository } from '~/shared/infra/drizzle/repository'
-import {
-  ResearchSessionStatus,
-  ResearchStepStatus,
-} from '~/shared/infra/drizzle/schema'
+import { ResearchSessionStatus } from '~/shared/infra/drizzle/schema'
 import { Answer } from '~/shared/infra/drizzle/schemas'
 import {
   type SessionEvent,
@@ -56,6 +53,12 @@ import { MainLive } from '~/shared/runtime/main'
 
 const StreamRequest = Schema.Struct({
   prompt: Schema.String,
+  /**
+   * The browser's `Last-Event-ID` (forwarded by the worker entry).
+   * Defaults to 0 — meaning replay everything if the session has any
+   * persisted events, otherwise start fresh.
+   */
+  lastEventId: Schema.optional(Schema.Number),
 })
 
 const AnswerRequest = Schema.Struct({
@@ -155,15 +158,14 @@ export class ResearchDO extends DurableObject {
       return toErrorResponse(new SchemaViolation({ cause: decoded.left }))
     }
 
-    return this.openStream(decoded.right.prompt)
+    return this.openStream(decoded.right.prompt, decoded.right.lastEventId ?? 0)
   }
 
-  private openStream(prompt: string): Response {
+  private openStream(prompt: string, lastEventId: number): Response {
     const { readable, writable } = new TransformStream<Uint8Array, Uint8Array>()
     const writer = writable.getWriter()
     const encoder = new TextEncoder()
     const sessionId = this.sessionId
-    const startStepNumber = this.nextStepNumber
 
     const program = Effect.gen(this, function* (this: ResearchDO) {
       const repo = yield* ResearchRepository
@@ -173,33 +175,24 @@ export class ResearchDO extends DurableObject {
       )
 
       const persistStep = (event: AgentEvent) =>
-        repo.appendStep({
-          sessionId,
-          stepNumber: event.id,
-          toolName: 'toolName' in event ? event.toolName : null,
-          toolRequest:
-            event.type === 'tool_invoked' ? JSON.stringify(event.args) : null,
-          toolResponse:
-            event.type === 'tool_result' ? JSON.stringify(event.result) : null,
-          llmResponse:
-            event.type === 'agent_thinking'
-              ? event.text
-              : event.type === 'done'
-                ? event.finalText
-                : null,
-          status: ResearchStepStatus.success,
-        })
+        repo.appendStep({ sessionId, event })
 
       const writeFrame = (event: AgentEvent) =>
         Effect.promise(() => writer.write(encoder.encode(encode(event))))
 
-      yield* runLoop(
-        { prompt, startStepNumber },
+      // sessionEventStream emits replay events first (already persisted —
+      // we only write frames), then live events (which run through
+      // `persistLive`). Frame writes happen for both so the browser sees
+      // a continuous stream from `lastEventId + 1` onwards.
+      yield* sessionEventStream({
+        prompt,
+        sessionId,
+        lastEventId,
         catalog,
-      ).pipe(
+        persistLive: persistStep,
+      }).pipe(
         Stream.tap((event) =>
           Effect.gen(this, function* (this: ResearchDO) {
-            yield* persistStep(event)
             yield* writeFrame(event)
             yield* Ref.set(lastEventTypeRef, event.type)
             if (event.id + 1 > this.nextStepNumber) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -44,6 +44,7 @@ const PRD_PATH = /^\/session\/([^/]+)\/prd$/
 
 const handleStream = (
   sessionId: string,
+  request: Request,
   env: Env,
 ): Effect.Effect<Response, AppError, ResearchRepository> =>
   Effect.gen(function* () {
@@ -53,11 +54,20 @@ const handleStream = (
         Effect.fail(new NotFound({ resource: `session ${sessionId}` })),
       ),
     )
+    // The browser's EventSource sets `Last-Event-ID` automatically on
+    // reconnect. Coerce non-numeric values to 0 so a missing or
+    // malformed header behaves like "start from scratch".
+    const headerValue = request.headers.get('last-event-id')
+    const parsed = headerValue !== null ? Number(headerValue) : NaN
+    const lastEventId = Number.isFinite(parsed) ? parsed : 0
     return yield* Effect.promise(() =>
       doStub(env, sessionId).fetch('https://do/stream', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ prompt: session.initialPrompt }),
+        body: JSON.stringify({
+          prompt: session.initialPrompt,
+          lastEventId,
+        }),
       }),
     )
   })
@@ -135,7 +145,7 @@ export default {
 
     const streamMatch = url.pathname.match(STREAM_PATH)
     if (streamMatch && request.method === 'GET') {
-      return runRequest(env, handleStream(streamMatch[1]!, env))
+      return runRequest(env, handleStream(streamMatch[1]!, request, env))
     }
 
     const prdMatch = url.pathname.match(PRD_PATH)

--- a/src/shared/infra/drizzle/repository.test.ts
+++ b/src/shared/infra/drizzle/repository.test.ts
@@ -1,0 +1,164 @@
+/**
+ * `ResearchRepository.getStepsAfter` — used by the SSE replay path on
+ * `EventSource` reconnect (Slice 5). Reads events with `stepNumber >
+ * lastEventId` for one session, ordered. The events round-trip through
+ * `appendStep`, so a replayed event is bit-equal to the originally
+ * emitted one (id + type + payload).
+ *
+ * Tests run against the in-memory adapter; the D1 adapter shares the
+ * same Effect Schema decode path, so behaviour drift between the two
+ * surfaces as a row-decode error rather than as silently divergent
+ * results.
+ */
+import { describe, it, expect } from '@effect/vitest'
+import { Effect } from 'effect'
+import {
+  RepositoryInMemoryLive,
+  ResearchRepository,
+} from './repository'
+import { ResearchSessionStatus } from './schema'
+import type { AgentEvent } from '~/shared/sse/events'
+
+const sampleEvents: ReadonlyArray<AgentEvent> = [
+  { id: 1, type: 'agent_thinking', text: 'pondering' },
+  {
+    id: 2,
+    type: 'tool_invoked',
+    toolName: 'echo',
+    args: { text: 'hi' },
+  },
+  {
+    id: 3,
+    type: 'tool_result',
+    toolName: 'echo',
+    result: { text: 'hi' },
+  },
+  {
+    id: 4,
+    type: 'question_asked',
+    questionId: 'q_1',
+    question: 'why?',
+    recommendation: 'because',
+    rationale: 'reasons',
+    kind: 'single',
+  },
+  {
+    id: 5,
+    type: 'prd_section_written',
+    section: 'goal',
+    content: 'make it dark',
+  },
+  { id: 6, type: 'done', finalText: 'all good' },
+]
+
+const seedSession = (id: string) =>
+  Effect.gen(function* () {
+    const repo = yield* ResearchRepository
+    const now = new Date(0)
+    yield* repo.createSession({
+      id,
+      initialPrompt: `prompt-${id}`,
+      status: ResearchSessionStatus.active,
+      createdAt: now,
+      updatedAt: now,
+    })
+  })
+
+describe('ResearchRepository.getStepsAfter', () => {
+  it.effect('returns all events when lastEventId is 0', () =>
+    Effect.gen(function* () {
+      yield* seedSession('s1')
+      const repo = yield* ResearchRepository
+      for (const event of sampleEvents) {
+        yield* repo.appendStep({ sessionId: 's1', event })
+      }
+
+      const all = yield* repo.getStepsAfter('s1', 0)
+      expect(all).toEqual(sampleEvents)
+    }).pipe(Effect.provide(RepositoryInMemoryLive)),
+  )
+
+  it.effect('filters out events with stepNumber <= lastEventId', () =>
+    Effect.gen(function* () {
+      yield* seedSession('s1')
+      const repo = yield* ResearchRepository
+      for (const event of sampleEvents) {
+        yield* repo.appendStep({ sessionId: 's1', event })
+      }
+
+      const after3 = yield* repo.getStepsAfter('s1', 3)
+      expect(after3).toEqual(sampleEvents.slice(3))
+
+      const after5 = yield* repo.getStepsAfter('s1', 5)
+      expect(after5).toEqual(sampleEvents.slice(5))
+    }).pipe(Effect.provide(RepositoryInMemoryLive)),
+  )
+
+  it.effect('returns an empty array when lastEventId is past the tail', () =>
+    Effect.gen(function* () {
+      yield* seedSession('s1')
+      const repo = yield* ResearchRepository
+      for (const event of sampleEvents) {
+        yield* repo.appendStep({ sessionId: 's1', event })
+      }
+
+      const empty = yield* repo.getStepsAfter('s1', 99)
+      expect(empty).toEqual([])
+    }).pipe(Effect.provide(RepositoryInMemoryLive)),
+  )
+
+  it.effect('orders events by stepNumber even if appended out of order', () =>
+    Effect.gen(function* () {
+      yield* seedSession('s1')
+      const repo = yield* ResearchRepository
+      // Append in reverse order — getStepsAfter must restore ordering.
+      for (const event of [...sampleEvents].reverse()) {
+        yield* repo.appendStep({ sessionId: 's1', event })
+      }
+
+      const all = yield* repo.getStepsAfter('s1', 0)
+      expect(all).toEqual(sampleEvents)
+    }).pipe(Effect.provide(RepositoryInMemoryLive)),
+  )
+
+  it.effect('does not leak events from other sessions', () =>
+    Effect.gen(function* () {
+      yield* seedSession('s1')
+      yield* seedSession('s2')
+      const repo = yield* ResearchRepository
+
+      yield* repo.appendStep({
+        sessionId: 's1',
+        event: { id: 1, type: 'agent_thinking', text: 'session-one' },
+      })
+      yield* repo.appendStep({
+        sessionId: 's2',
+        event: { id: 1, type: 'agent_thinking', text: 'session-two' },
+      })
+
+      const s1 = yield* repo.getStepsAfter('s1', 0)
+      expect(s1).toEqual([
+        { id: 1, type: 'agent_thinking', text: 'session-one' },
+      ])
+
+      const s2 = yield* repo.getStepsAfter('s2', 0)
+      expect(s2).toEqual([
+        { id: 1, type: 'agent_thinking', text: 'session-two' },
+      ])
+    }).pipe(Effect.provide(RepositoryInMemoryLive)),
+  )
+
+  it.effect('round-trips every AgentEvent variant through appendStep', () =>
+    Effect.gen(function* () {
+      yield* seedSession('s1')
+      const repo = yield* ResearchRepository
+      for (const event of sampleEvents) {
+        yield* repo.appendStep({ sessionId: 's1', event })
+      }
+      const reread = yield* repo.getStepsAfter('s1', 0)
+      // Bit-equality is the contract: replayed events must match the
+      // original emission so the frontend reducer is idempotent.
+      expect(reread).toEqual(sampleEvents)
+    }).pipe(Effect.provide(RepositoryInMemoryLive)),
+  )
+})

--- a/src/shared/infra/drizzle/repository.ts
+++ b/src/shared/infra/drizzle/repository.ts
@@ -14,7 +14,7 @@
  * down.
  */
 import { drizzle } from 'drizzle-orm/d1'
-import { and, asc, eq } from 'drizzle-orm'
+import { and, asc, eq, gt } from 'drizzle-orm'
 import { Context, Effect, Layer, ParseResult, Ref, Schema } from 'effect'
 import {
   type RepositoryError,
@@ -28,6 +28,7 @@ import {
   researchSessions,
   researchSteps,
   ResearchSessionStatus,
+  ResearchStepStatus,
 } from './schema'
 import {
   type Answer,
@@ -36,8 +37,8 @@ import {
   ResearchQuestion,
   ResearchSessionRow,
   type SessionStatus,
-  StepStatusSchema,
 } from './schemas'
+import { AgentEvent } from '~/shared/sse/events'
 
 /* ------------------------------------------------------------------ *
  * Domain inputs (writes)
@@ -51,14 +52,15 @@ export interface NewSession {
   readonly updatedAt: Date
 }
 
+/**
+ * One persisted Research Step = one emitted `AgentEvent`. The repo
+ * derives the legacy debug columns (`toolName`, `llmResponse`, etc.)
+ * from `event` so they stay populated for ad-hoc SQL, but only the
+ * `event` column is read back on the SSE replay path.
+ */
 export interface NewStep {
   readonly sessionId: string
-  readonly stepNumber: number
-  readonly toolName: string | null
-  readonly llmResponse: string | null
-  readonly toolRequest: string | null
-  readonly toolResponse: string | null
-  readonly status: Schema.Schema.Type<typeof StepStatusSchema>
+  readonly event: AgentEvent
 }
 
 export interface NewQuestion {
@@ -94,6 +96,10 @@ export class ResearchRepository extends Context.Tag('ResearchRepository')<
       id: string,
     ) => Effect.Effect<ResearchSessionRow, RepositoryError>
     readonly appendStep: (input: NewStep) => Effect.Effect<void, RepositoryError>
+    readonly getStepsAfter: (
+      sessionId: string,
+      lastEventId: number,
+    ) => Effect.Effect<ReadonlyArray<AgentEvent>, RepositoryError>
     readonly recordQuestion: (
       input: NewQuestion,
     ) => Effect.Effect<void, RepositoryError>
@@ -136,6 +142,66 @@ const decodeRow =
     )
 
 const encodeAnswer = Schema.encodeSync(AnswerJson)
+
+/**
+ * Project an `AgentEvent` into the row-shape `research_steps` expects.
+ * Centralised here so the D1 and in-memory adapters can't drift on the
+ * derived columns. The encoded `event` JSON is the source of truth.
+ */
+const encodeAgentEvent = Schema.encodeSync(AgentEvent)
+const decodeAgentEventUnknown = Schema.decodeUnknown(AgentEvent)
+const decodeStepEvent = (raw: unknown): Effect.Effect<AgentEvent, RepositoryRowDecodeError> =>
+  decodeAgentEventUnknown(raw).pipe(
+    Effect.mapError(
+      (cause: ParseResult.ParseError) =>
+        new RepositoryRowDecodeError({ entity: 'ResearchStep.event', cause }),
+    ),
+  )
+
+interface StepRowFields {
+  readonly sessionId: string
+  readonly stepNumber: number
+  readonly toolName: string | null
+  readonly llmResponse: string | null
+  readonly toolRequest: string | null
+  readonly toolResponse: string | null
+  readonly status: ResearchStepStatus
+  readonly event: string
+}
+
+const projectStep = (input: NewStep): StepRowFields => {
+  const { event } = input
+  const encoded = JSON.stringify(encodeAgentEvent(event))
+  return {
+    sessionId: input.sessionId,
+    stepNumber: event.id,
+    toolName: 'toolName' in event ? event.toolName : null,
+    toolRequest:
+      event.type === 'tool_invoked' ? JSON.stringify(event.args) : null,
+    toolResponse:
+      event.type === 'tool_result' ? JSON.stringify(event.result) : null,
+    llmResponse:
+      event.type === 'agent_thinking'
+        ? event.text
+        : event.type === 'done'
+          ? event.finalText
+          : null,
+    status: ResearchStepStatus.success,
+    event: encoded,
+  }
+}
+
+const parseEventColumn = (
+  raw: string,
+): Effect.Effect<AgentEvent, RepositoryRowDecodeError> =>
+  Effect.try({
+    try: () => JSON.parse(raw) as unknown,
+    catch: (cause) =>
+      new RepositoryRowDecodeError({
+        entity: 'ResearchStep.event',
+        cause: cause as ParseResult.ParseError,
+      }),
+  }).pipe(Effect.flatMap(decodeStepEvent))
 
 /* ------------------------------------------------------------------ *
  * D1 / Drizzle adapter
@@ -190,15 +256,25 @@ const makeD1 = (env: { D1: D1Database }) => {
 
     appendStep: (input) =>
       tryDb(async () => {
-        await db.insert(researchSteps).values({
-          sessionId: input.sessionId,
-          stepNumber: input.stepNumber,
-          toolName: input.toolName,
-          toolRequest: input.toolRequest,
-          toolResponse: input.toolResponse,
-          llmResponse: input.llmResponse,
-          status: input.status,
-        })
+        const row = projectStep(input)
+        await db.insert(researchSteps).values(row)
+      }),
+
+    getStepsAfter: (sessionId, lastEventId) =>
+      Effect.gen(function* () {
+        const rows = yield* tryDb(() =>
+          db
+            .select({ event: researchSteps.event })
+            .from(researchSteps)
+            .where(
+              and(
+                eq(researchSteps.sessionId, sessionId),
+                gt(researchSteps.stepNumber, lastEventId),
+              ),
+            )
+            .orderBy(asc(researchSteps.stepNumber)),
+        )
+        return yield* Effect.forEach(rows, (r) => parseEventColumn(r.event))
       }),
 
     recordQuestion: (input) =>
@@ -315,9 +391,7 @@ export const RepositoryInMemoryLive: Layer.Layer<ResearchRepository> =
       const sessions = yield* Ref.make(
         new Map<string, ResearchSessionRow>(),
       )
-      const steps = yield* Ref.make<
-        Array<{ sessionId: string; stepNumber: number; toolName: string | null }>
-      >([])
+      const steps = yield* Ref.make<Array<StepRowFields>>([])
       const questions = yield* Ref.make(new Map<string, RawQuestionRow>())
       const prdSeq = yield* Ref.make(0)
       const prdRows = yield* Ref.make<Array<RawPrdSectionRow>>([])
@@ -368,14 +442,20 @@ export const RepositoryInMemoryLive: Layer.Layer<ResearchRepository> =
           }),
 
         appendStep: (input) =>
-          Ref.update(steps, (arr) => [
-            ...arr,
-            {
-              sessionId: input.sessionId,
-              stepNumber: input.stepNumber,
-              toolName: input.toolName,
-            },
-          ]),
+          Ref.update(steps, (arr) => [...arr, projectStep(input)]),
+
+        getStepsAfter: (sessionId, lastEventId) =>
+          Effect.gen(function* () {
+            const arr = yield* Ref.get(steps)
+            const filtered = arr
+              .filter(
+                (r) => r.sessionId === sessionId && r.stepNumber > lastEventId,
+              )
+              .sort((a, b) => a.stepNumber - b.stepNumber)
+            return yield* Effect.forEach(filtered, (r) =>
+              parseEventColumn(r.event),
+            )
+          }),
 
         recordQuestion: (input) =>
           Ref.update(questions, (m) => {

--- a/src/shared/infra/drizzle/schema.ts
+++ b/src/shared/infra/drizzle/schema.ts
@@ -66,6 +66,13 @@ export const researchSteps = sqliteTable('research_steps', (schema) => ({
   toolRequest: schema.text(),
   toolResponse: schema.text(),
   errorMessage: schema.text(),
+  /**
+   * Source-of-truth for SSE replay (Slice 5): the full encoded
+   * `AgentEvent` (id + type + payload) as JSON. The other columns above
+   * are kept for legibility and ad-hoc SQL — they're derived from this
+   * one and not read by the app.
+   */
+  event: schema.text().notNull(),
   status: schema
     .text({
       mode: 'text',

--- a/src/shared/research/replay.integration.test.ts
+++ b/src/shared/research/replay.integration.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Slice 5 acceptance criterion: kill the stream mid-session, open a
+ * new EventSource with a `Last-Event-ID`, verify the event sequence
+ * from that id forward is complete and ordered.
+ *
+ * Simulated end-to-end below `server.ts` / DO HTTP — directly through
+ * `sessionEventStream` so the assertion stays at the behavioural seam
+ * the DO consumes. The DO + worker are thin wrappers over this stream
+ * (header parse, body parse, frame write); their wiring is verified by
+ * `pnpm build` / smoke testing, not by reproducing a Cloudflare runtime
+ * in vitest.
+ */
+import { describe, it, expect } from '@effect/vitest'
+import { Chunk, Clock, Effect, Layer, Stream } from 'effect'
+import type OpenAI from 'openai'
+import { IdsTest } from '~/shared/domain/ids'
+import { GroqStub } from '~/shared/infra/groq/client'
+import {
+  RepositoryInMemoryLive,
+  ResearchRepository,
+} from '~/shared/infra/drizzle/repository'
+import { ResearchSessionStatus } from '~/shared/infra/drizzle/schema'
+import { makeCatalog, SessionContext } from '~/shared/agent/tools/catalog'
+import { builtinTools } from '~/shared/agent/tools/builtin'
+import type { AgentEvent } from '~/shared/sse/events'
+import { sessionEventStream } from './replay'
+
+const SessionFixed = Layer.succeed(SessionContext, { sessionId: 's1' })
+
+const askQuestionCompletion: OpenAI.ChatCompletion = {
+  id: 'c1',
+  object: 'chat.completion',
+  created: 0,
+  model: 'm',
+  choices: [
+    {
+      index: 0,
+      message: {
+        role: 'assistant',
+        content: 'thinking about your feature…',
+        refusal: null,
+        tool_calls: [
+          {
+            id: 'tc1',
+            type: 'function',
+            function: {
+              name: 'askQuestion',
+              arguments: JSON.stringify({
+                question: 'Who are the primary users?',
+                recommendation: 'Power users',
+                rationale: 'They tolerate complexity',
+              }),
+            },
+          },
+        ],
+      },
+      finish_reason: 'tool_calls',
+      logprobs: null,
+    },
+  ],
+} as OpenAI.ChatCompletion
+
+const catalog = makeCatalog(builtinTools)
+
+const seed = Effect.gen(function* () {
+  const repo = yield* ResearchRepository
+  const millis = yield* Clock.currentTimeMillis
+  yield* repo.createSession({
+    id: 's1',
+    initialPrompt: 'design a CLI dark mode toggler',
+    status: ResearchSessionStatus.active,
+    createdAt: new Date(millis),
+    updatedAt: new Date(millis),
+  })
+})
+
+describe('Slice 5: kill mid-session, reconnect with Last-Event-ID', () => {
+  it.effect(
+    'replays missed events bit-equal to the originals; no dupes, no gaps',
+    () =>
+      Effect.gen(function* () {
+        yield* seed
+        const repo = yield* ResearchRepository
+
+        const persistLive = (event: AgentEvent) =>
+          repo.appendStep({ sessionId: 's1', event })
+
+        // ---------- Phase 1 — initial connection ----------
+        // The agent runs one tick, emits a multi-event sequence, then
+        // pauses on `question_asked`. The DO would persist each event
+        // as it streams; we mirror that with `persistLive`.
+        const phase1 = yield* Stream.runCollect(
+          sessionEventStream({
+            prompt: 'design a CLI dark mode toggler',
+            sessionId: 's1',
+            lastEventId: 0,
+            catalog,
+            persistLive,
+          }),
+        ).pipe(Effect.provide(GroqStub.layer([askQuestionCompletion])))
+
+        const original = Chunk.toReadonlyArray(
+          phase1,
+        ) as ReadonlyArray<AgentEvent>
+
+        // Sanity: the tick produced agent_thinking → tool_invoked →
+        // question_asked, and persisted them all.
+        expect(original.map((e) => e.type)).toEqual([
+          'agent_thinking',
+          'tool_invoked',
+          'question_asked',
+        ])
+
+        // Production DO would call `transitionTo('askQuestion')` which
+        // flips the row to `waiting_for_user`. Mirror that here so the
+        // reconnect path doesn't fire a fresh LLM call.
+        const millis = yield* Clock.currentTimeMillis
+        yield* repo.setSessionStatus(
+          's1',
+          ResearchSessionStatus.waitingForUser,
+          new Date(millis),
+        )
+
+        // ---------- Phase 2 — reconnect mid-session ----------
+        // Suppose the browser only managed to receive event 1 before
+        // the connection dropped. EventSource will reconnect with
+        // `Last-Event-ID: 1`. The server replays events 2..3.
+        const cutAt = 1
+        const lastSeenId = original[cutAt - 1]!.id
+
+        const phase2 = yield* Stream.runCollect(
+          sessionEventStream({
+            prompt: 'design a CLI dark mode toggler',
+            sessionId: 's1',
+            lastEventId: lastSeenId,
+            catalog,
+            persistLive,
+          }),
+        )
+          // Empty Groq turns: a fresh LLM call here would crash on
+          // missing turn 0, which is the right failure shape for
+          // "this path must not call the model".
+          .pipe(Effect.provide(GroqStub.layer([])))
+
+        const replayed = Chunk.toReadonlyArray(
+          phase2,
+        ) as ReadonlyArray<AgentEvent>
+
+        // Bit-equality: same ids, same types, same payloads.
+        expect(replayed).toEqual(original.slice(cutAt))
+
+        // Explicit: contiguous step numbers from lastSeenId + 1 onward.
+        expect(replayed.map((e) => e.id)).toEqual(
+          original.slice(cutAt).map((e) => e.id),
+        )
+        const ids = replayed.map((e) => e.id)
+        for (let i = 1; i < ids.length; i++) {
+          expect(ids[i]).toBe(ids[i - 1]! + 1)
+        }
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(RepositoryInMemoryLive, IdsTest, SessionFixed),
+        ),
+      ),
+  )
+
+  it.effect(
+    'reconnect from event 0 (no Last-Event-ID) replays everything bit-equal',
+    () =>
+      Effect.gen(function* () {
+        yield* seed
+        const repo = yield* ResearchRepository
+        const persistLive = (event: AgentEvent) =>
+          repo.appendStep({ sessionId: 's1', event })
+
+        const phase1 = yield* Stream.runCollect(
+          sessionEventStream({
+            prompt: 'p',
+            sessionId: 's1',
+            lastEventId: 0,
+            catalog,
+            persistLive,
+          }),
+        ).pipe(Effect.provide(GroqStub.layer([askQuestionCompletion])))
+        const original = Chunk.toReadonlyArray(
+          phase1,
+        ) as ReadonlyArray<AgentEvent>
+
+        const millis = yield* Clock.currentTimeMillis
+        yield* repo.setSessionStatus(
+          's1',
+          ResearchSessionStatus.waitingForUser,
+          new Date(millis),
+        )
+
+        // Reconnect with `Last-Event-ID: 0` — same as no header.
+        const phase2 = yield* Stream.runCollect(
+          sessionEventStream({
+            prompt: 'p',
+            sessionId: 's1',
+            lastEventId: 0,
+            catalog,
+            persistLive,
+          }),
+        ).pipe(Effect.provide(GroqStub.layer([])))
+        const replayed = Chunk.toReadonlyArray(
+          phase2,
+        ) as ReadonlyArray<AgentEvent>
+
+        expect(replayed).toEqual(original)
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(RepositoryInMemoryLive, IdsTest, SessionFixed),
+        ),
+      ),
+  )
+})

--- a/src/shared/research/replay.test.ts
+++ b/src/shared/research/replay.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Slice 5: `sessionEventStream` composes replay + live.
+ *
+ * The DO calls this when the browser opens `/session/:id/stream` (with
+ * or without a `Last-Event-ID`). The stream:
+ *
+ *   1. Emits all persisted events with `stepNumber > lastEventId` in
+ *      order — replay.
+ *   2. If the session is still active, attaches the live `runLoop` and
+ *      continues from the next step number. Otherwise the stream ends
+ *      after replay (no fresh LLM call against a paused session).
+ *
+ * The replayed events are bit-equal to the originals so the frontend
+ * reducer is idempotent and reconnect is invisible to the user.
+ */
+import { describe, it, expect } from '@effect/vitest'
+import { Chunk, Effect, Layer, Stream } from 'effect'
+import type OpenAI from 'openai'
+import { IdsTest } from '~/shared/domain/ids'
+import { GroqStub } from '~/shared/infra/groq/client'
+import {
+  RepositoryInMemoryLive,
+  ResearchRepository,
+} from '~/shared/infra/drizzle/repository'
+import { ResearchSessionStatus } from '~/shared/infra/drizzle/schema'
+import { makeCatalog, SessionContext } from '~/shared/agent/tools/catalog'
+import { builtinTools } from '~/shared/agent/tools/builtin'
+import type { AgentEvent } from '~/shared/sse/events'
+import { sessionEventStream } from './replay'
+
+const SessionFixed = (id: string) =>
+  Layer.succeed(SessionContext, { sessionId: id })
+
+const finalCompletion = (
+  cmplId: string,
+  text: string,
+): OpenAI.ChatCompletion =>
+  ({
+    id: cmplId,
+    object: 'chat.completion',
+    created: 0,
+    model: 'm',
+    choices: [
+      {
+        index: 0,
+        message: {
+          role: 'assistant',
+          content: text,
+          refusal: null,
+        },
+        finish_reason: 'stop',
+        logprobs: null,
+      },
+    ],
+  }) as OpenAI.ChatCompletion
+
+const seedSession = (
+  id: string,
+  status: ResearchSessionStatus,
+  events: ReadonlyArray<AgentEvent>,
+) =>
+  Effect.gen(function* () {
+    const repo = yield* ResearchRepository
+    const now = new Date(0)
+    yield* repo.createSession({
+      id,
+      initialPrompt: `prompt-${id}`,
+      status,
+      createdAt: now,
+      updatedAt: now,
+    })
+    for (const event of events) {
+      yield* repo.appendStep({ sessionId: id, event })
+    }
+  })
+
+const catalog = makeCatalog(builtinTools)
+
+describe('sessionEventStream — replay then live', () => {
+  it.effect(
+    'on an active session: emits replay events first, then live events with continuing ids',
+    () =>
+      Effect.gen(function* () {
+        const seeded: ReadonlyArray<AgentEvent> = [
+          { id: 1, type: 'agent_thinking', text: 'first' },
+          { id: 2, type: 'agent_thinking', text: 'second' },
+          { id: 3, type: 'agent_thinking', text: 'third' },
+        ]
+        yield* seedSession('s1', ResearchSessionStatus.active, seeded)
+
+        const collected = yield* Stream.runCollect(
+          sessionEventStream({
+            prompt: 'continue please',
+            sessionId: 's1',
+            lastEventId: 1,
+            catalog,
+            persistLive: () => Effect.void,
+          }),
+        ).pipe(
+          Effect.provide(GroqStub.layer([finalCompletion('c1', 'all done')])),
+        )
+        const events = Chunk.toReadonlyArray(collected) as ReadonlyArray<
+          AgentEvent
+        >
+
+        // First two: replay events 2 and 3 from the persisted store.
+        expect(events.slice(0, 2)).toEqual(seeded.slice(1))
+
+        // Live tail follows: agent_thinking + done from the GroqStub.
+        // ids continue from 4 onward (max replay id was 3).
+        expect(events[2]).toEqual({
+          id: 4,
+          type: 'agent_thinking',
+          text: 'all done',
+        })
+        expect(events[3]).toEqual({
+          id: 5,
+          type: 'done',
+          finalText: 'all done',
+        })
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            RepositoryInMemoryLive,
+            IdsTest,
+            SessionFixed('s1'),
+          ),
+        ),
+      ),
+  )
+
+  it.effect(
+    'on a paused (waiting_for_user) session: emits only replay, no live tick',
+    () =>
+      Effect.gen(function* () {
+        const seeded: ReadonlyArray<AgentEvent> = [
+          { id: 1, type: 'agent_thinking', text: 'a' },
+          {
+            id: 2,
+            type: 'question_asked',
+            questionId: 'q_1',
+            question: 'q?',
+            recommendation: 'r',
+            rationale: 'why',
+            kind: 'single',
+          },
+        ]
+        yield* seedSession(
+          's1',
+          ResearchSessionStatus.waitingForUser,
+          seeded,
+        )
+
+        // GroqStub layer with no turns — if the live tick runs, it
+        // crashes on completion #0 missing.
+        const collected = yield* Stream.runCollect(
+          sessionEventStream({
+            prompt: 'p',
+            sessionId: 's1',
+            lastEventId: 0,
+            catalog,
+            persistLive: () => Effect.void,
+          }),
+        ).pipe(Effect.provide(GroqStub.layer([])))
+
+        const events = Chunk.toReadonlyArray(collected) as ReadonlyArray<
+          AgentEvent
+        >
+        expect(events).toEqual(seeded)
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            RepositoryInMemoryLive,
+            IdsTest,
+            SessionFixed('s1'),
+          ),
+        ),
+      ),
+  )
+
+  it.effect(
+    'when lastEventId covers everything persisted: emits no replay, only live',
+    () =>
+      Effect.gen(function* () {
+        yield* seedSession('s1', ResearchSessionStatus.active, [
+          { id: 1, type: 'agent_thinking', text: 'old' },
+        ])
+
+        const collected = yield* Stream.runCollect(
+          sessionEventStream({
+            prompt: 'p',
+            sessionId: 's1',
+            lastEventId: 99,
+            catalog,
+            persistLive: () => Effect.void,
+          }),
+        ).pipe(
+          Effect.provide(GroqStub.layer([finalCompletion('c1', 'fresh')])),
+        )
+        const events = Chunk.toReadonlyArray(collected) as ReadonlyArray<
+          AgentEvent
+        >
+
+        // Only live events. Live ids continue from lastEventId + 1.
+        expect(events).toEqual([
+          { id: 100, type: 'agent_thinking', text: 'fresh' },
+          { id: 101, type: 'done', finalText: 'fresh' },
+        ])
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            RepositoryInMemoryLive,
+            IdsTest,
+            SessionFixed('s1'),
+          ),
+        ),
+      ),
+  )
+})

--- a/src/shared/research/replay.ts
+++ b/src/shared/research/replay.ts
@@ -1,0 +1,85 @@
+/**
+ * `sessionEventStream` — composes "replay then live" for the SSE
+ * endpoint (Slice 5).
+ *
+ * On every `GET /session/:id/stream`, the server hands us:
+ *   - the session's `prompt` (in case the live loop has to start),
+ *   - the `Last-Event-ID` the browser sent (default 0 if absent),
+ *   - the `catalog` of agent tools.
+ *
+ * The stream emits, in order:
+ *
+ *   1. Every persisted event with `stepNumber > lastEventId`, decoded
+ *      back into the original `AgentEvent` (same id, same type, same
+ *      payload). This is the replay.
+ *   2. If — and only if — the session is still `active`, the live
+ *      `runLoop` continues from the next step number.
+ *
+ * If the session is paused (`waiting_for_user`) or terminal
+ * (`completed`, `failed`, `abandoned`), only the replay runs. We don't
+ * fire a fresh LLM call against a session that's already done its turn.
+ */
+import { Effect, Stream } from 'effect'
+import type { LoopError, RepositoryError } from '~/shared/domain/errors'
+import { Groq } from '~/shared/infra/groq/client'
+import { ResearchRepository } from '~/shared/infra/drizzle/repository'
+import { ResearchSessionStatus } from '~/shared/infra/drizzle/schema'
+import { runLoop } from '~/shared/agent/loop'
+import type { ToolCatalog } from '~/shared/agent/tools/catalog'
+import type { AgentEvent } from '~/shared/sse/events'
+
+export interface SessionEventStreamInput<R, E, R2, E2> {
+  readonly prompt: string
+  readonly sessionId: string
+  readonly lastEventId: number
+  readonly catalog: ToolCatalog<R, E>
+  readonly model?: string
+  readonly softCap?: number
+  readonly hardCap?: number
+  /**
+   * Side effect for each *live* event — typically `appendStep`. Replayed
+   * events are not handed to this callback because they're already in
+   * the persisted log.
+   */
+  readonly persistLive: (event: AgentEvent) => Effect.Effect<void, E2, R2>
+}
+
+export const sessionEventStream = <R, E, R2, E2>(
+  input: SessionEventStreamInput<R, E, R2, E2>,
+): Stream.Stream<
+  AgentEvent,
+  LoopError | E | E2 | RepositoryError,
+  R | R2 | Groq | ResearchRepository
+> =>
+  Stream.unwrap(
+    Effect.gen(function* () {
+      const repo = yield* ResearchRepository
+      const replayed = yield* repo.getStepsAfter(
+        input.sessionId,
+        input.lastEventId,
+      )
+      const session = yield* repo.getSessionById(input.sessionId)
+
+      const replayStream = Stream.fromIterable(replayed)
+
+      if (session.status !== ResearchSessionStatus.active) {
+        return replayStream
+      }
+
+      const maxId = replayed.reduce(
+        (m, e) => (e.id > m ? e.id : m),
+        input.lastEventId,
+      )
+      const liveStream = runLoop(
+        {
+          prompt: input.prompt,
+          model: input.model,
+          softCap: input.softCap,
+          hardCap: input.hardCap,
+          startStepNumber: maxId + 1,
+        },
+        input.catalog,
+      ).pipe(Stream.tap(input.persistLive))
+      return Stream.concat(replayStream, liveStream)
+    }),
+  )


### PR DESCRIPTION
## Summary

- Added `event` column to `research_steps` table storing full encoded `AgentEvent` JSON as source of truth
- Implemented `ResearchRepository.getStepsAfter()` to retrieve persisted events by `lastEventId` for replay on reconnect
- Updated stream handler to extract and forward browser's `Last-Event-ID` header to the DO
- Separated replay path (read from DB, no persist) from live path (run agent, persist new events only)
- Events from both paths written as SSE frames so browser receives continuous stream from `lastEventId + 1` onwards

## Testing

- Unit tests verify `getStepsAfter` filtering (`stepNumber > lastEventId`), ordering, session isolation, and round-trip fidelity through `appendStep`
- Integration tests kill stream mid-session and reconnect with various `Last-Event-ID` values
- Verify replayed events are bit-equal to originals (same id/type/payload), no duplicates, no gaps
- Verify replay path does not trigger new LLM calls (empty Groq layer would crash if model called)
- Manual smoke test: kill browser connection mid-session, reconnect, verify event sequence completes