### PR TITLE
Add research tools for agent recommendations (webSearch, searchLibraryDocs, readUrl)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,19 @@ See [`CONTEXT.md`](./CONTEXT.md) for the domain language.
 
 ## Required secrets
 
-| Name           | Purpose                                                              |
-| -------------- | -------------------------------------------------------------------- |
-| `GROQ_API_KEY` | API key for Groq Cloud. Used by `src/shared/infra/groq/client.ts`.   |
+| Name            | Purpose                                                                                                                                                                                            |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GROQ_API_KEY`  | API key for Groq Cloud. Used by `src/shared/infra/groq/client.ts`. **Required**.                                                                                                                   |
+| `BRAVE_API_KEY` | API key for Brave Search. Used by `src/shared/infra/brave/client.ts` to back the `webSearch` research tool. **Required** for the `webSearch` tool; agent falls back if absent but recommendations will be ungrounded. Free tier: 2,000 queries/month. |
 
-For local dev, put it in `.env` at the project root. For deploys, configure it
-through Alchemy / Cloudflare secrets.
+Context7 (`searchLibraryDocs` tool) uses the public `https://context7.com/api/v1`
+endpoint and requires no API key.
+
+`readUrl` makes outbound `fetch()` calls to whatever URL the agent picks; no
+key required, but bear in mind Cloudflare Workers' egress limits.
+
+For local dev, put secrets in `.env` at the project root. For deploys,
+configure them through Alchemy / Cloudflare secrets.
 
 ## Common scripts
 

--- a/alchemy.run.ts
+++ b/alchemy.run.ts
@@ -26,6 +26,12 @@ export const worker = await TanStackStart('worker', {
     D1: d1,
     // GROQ_API_KEY must be provided as a secret/env var. Required.
     GROQ_API_KEY: alchemy.secret(process.env.GROQ_API_KEY),
+    // BRAVE_API_KEY enables the `webSearch` research tool. Required for
+    // the agent to ground its recommendations on web search results;
+    // missing key causes `webSearch` calls to fail with `BraveAuthError`
+    // (the loop continues — the model will fall back to other tools or
+    // its own knowledge).
+    BRAVE_API_KEY: alchemy.secret(process.env.BRAVE_API_KEY),
     RESEARCH_DO: DurableObjectNamespace('RESEARCH_DO', {
       className: 'ResearchDO',
       sqlite: true,

--- a/src/do/research.ts
+++ b/src/do/research.ts
@@ -112,11 +112,13 @@ export class ResearchDO extends DurableObject {
     const env = this.env as unknown as {
       D1: D1Database
       GROQ_API_KEY?: string
+      BRAVE_API_KEY?: string
     }
     return Layer.merge(
       MainLive({
         D1: env.D1,
         groq: { apiKey: env.GROQ_API_KEY },
+        brave: { apiKey: env.BRAVE_API_KEY },
       }),
       Layer.succeed(SessionContext, { sessionId: this.sessionId }),
     )

--- a/src/shared/agent/loop.ts
+++ b/src/shared/agent/loop.ts
@@ -58,7 +58,12 @@ const SYSTEM = (softCap: number): string =>
   `You are a Research agent grilling the user about a feature so you can produce a PRD.\n` +
   `Aim to finish in under ${softCap} tool calls. Always pair an askQuestion with a recommendation and rationale. ` +
   `When you have enough material, write PRD sections via writeOutput({ kind: 'prd_section', section, content }) ` +
-  `and then call finalize({ summary }).`
+  `and then call finalize({ summary }).\n\n` +
+  `Before recommending an answer to a non-trivial question, ground yourself with the research tools:\n` +
+  `  - webSearch({ query }) — Brave web search; use for sources, recent posts, comparisons.\n` +
+  `  - searchLibraryDocs({ library, query }) — Context7 docs lookup; use whenever the decision turns on a specific library or framework.\n` +
+  `  - readUrl({ url }) — fetch the readable text of a URL returned by webSearch when the snippet alone is insufficient.\n` +
+  `Prefer one or two targeted research calls per decision over guessing; cite the result back to the user in your rationale.`
 
 export const runLoop = <R, E>(
   input: RunLoopInput,

--- a/src/shared/agent/research-tools.integration.test.ts
+++ b/src/shared/agent/research-tools.integration.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Slice 7 integration: a session that calls a research tool and emits a
+ * `tool_result` event with the expected payload shape.
+ *
+ * Stubs:
+ *   - GroqStub      — returns one tool-call turn (`webSearch`) then a `done`.
+ *   - BraveStub     — canned `{ results: […] }` payload.
+ *   - Context7Stub  — empty (unused this run; provided so types satisfy).
+ *   - UrlFetcherStub — empty (same reason).
+ *
+ * Asserted:
+ *   - `tool_invoked` carries `toolName: 'webSearch'` and the LLM-shaped args.
+ *   - `tool_result` carries the same `toolName` and the parsed Brave payload
+ *     under `result.results`.
+ */
+import { describe, it, expect } from '@effect/vitest'
+import { Chunk, Effect, Layer, Stream } from 'effect'
+import type OpenAI from 'openai'
+import { IdsTest } from '~/shared/domain/ids'
+import { GroqStub } from '~/shared/infra/groq/client'
+import { BraveStub } from '~/shared/infra/brave/client'
+import { Context7Stub } from '~/shared/infra/context7/client'
+import { UrlFetcherStub } from '~/shared/infra/url-fetcher/client'
+import { RepositoryInMemoryLive } from '~/shared/infra/drizzle/repository'
+import { runLoop } from './loop'
+import { makeCatalog, SessionContext } from './tools/catalog'
+import { builtinTools } from './tools/builtin'
+import { researchTools } from './tools/research'
+import type { AgentEvent } from '~/shared/sse/events'
+
+const SessionFixed = Layer.succeed(SessionContext, { sessionId: 's' })
+
+const completion = (
+  cmplId: string,
+  opts: {
+    content?: string
+    toolCalls?: ReadonlyArray<{
+      id: string
+      name: string
+      args: Record<string, unknown>
+    }>
+  },
+): OpenAI.ChatCompletion =>
+  ({
+    id: cmplId,
+    object: 'chat.completion',
+    created: 0,
+    model: 'm',
+    choices: [
+      {
+        index: 0,
+        message: {
+          role: 'assistant',
+          content: opts.content ?? '',
+          refusal: null,
+          tool_calls: opts.toolCalls?.map((c) => ({
+            id: c.id,
+            type: 'function',
+            function: {
+              name: c.name,
+              arguments: JSON.stringify(c.args),
+            },
+          })),
+        },
+        finish_reason: opts.toolCalls ? 'tool_calls' : 'stop',
+        logprobs: null,
+      },
+    ],
+  }) as OpenAI.ChatCompletion
+
+const allTools = [...builtinTools, ...researchTools] as const
+const catalog = makeCatalog(allTools)
+
+describe('Slice 7: research-tool integration', () => {
+  it.effect('runs a webSearch call and emits a tool_result event with the Brave payload', () =>
+    Effect.gen(function* () {
+      const turns: ReadonlyArray<OpenAI.ChatCompletion> = [
+        completion('c1', {
+          toolCalls: [
+            {
+              id: 'tc1',
+              name: 'webSearch',
+              args: { query: 'effect-ts schema validation' },
+            },
+          ],
+        }),
+        // After receiving the tool_result, the model "decides" to stop.
+        completion('c2', { content: 'Done with research.' }),
+      ]
+
+      const events = yield* Stream.runCollect(
+        runLoop({ prompt: 'research effect schema for me' }, catalog),
+      ).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            RepositoryInMemoryLive,
+            IdsTest,
+            SessionFixed,
+            GroqStub.layer(turns),
+            BraveStub.layer([
+              {
+                results: [
+                  {
+                    title: 'Effect Schema',
+                    url: 'https://effect.website/docs/schema/introduction',
+                    snippet: 'Schema is a powerful library...',
+                  },
+                ],
+              },
+            ]),
+            Context7Stub.layer({}),
+            UrlFetcherStub.layer([]),
+          ),
+        ),
+      )
+
+      const arr = Chunk.toReadonlyArray(events) as ReadonlyArray<AgentEvent>
+      const types = arr.map((e) => e.type)
+
+      // The loop should have streamed: agent_thinking, tool_invoked,
+      // tool_result, agent_thinking, done.
+      expect(types).toEqual([
+        'agent_thinking',
+        'tool_invoked',
+        'tool_result',
+        'agent_thinking',
+        'done',
+      ])
+
+      const invoked = arr.find((e) => e.type === 'tool_invoked')!
+      if (invoked.type !== 'tool_invoked') throw new Error('expected invoked')
+      expect(invoked.toolName).toBe('webSearch')
+      expect(invoked.args).toEqual({ query: 'effect-ts schema validation' })
+
+      const result = arr.find((e) => e.type === 'tool_result')!
+      if (result.type !== 'tool_result') throw new Error('expected result')
+      expect(result.toolName).toBe('webSearch')
+      expect(result.result).toEqual({
+        results: [
+          {
+            title: 'Effect Schema',
+            url: 'https://effect.website/docs/schema/introduction',
+            snippet: 'Schema is a powerful library...',
+          },
+        ],
+      })
+    }),
+  )
+})

--- a/src/shared/agent/tools/builtin.ts
+++ b/src/shared/agent/tools/builtin.ts
@@ -1,11 +1,17 @@
 /**
- * Built-in tool definitions — the four tools the Agent Loop ships with.
+ * Built-in tool definitions — the tools the Agent Loop ships with.
  *
- *   - `echoTool`         — diagnostic; replays its argument back to the LLM.
- *   - `askQuestionTool`  — HITL pause; persists a Question and signals the
- *                          loop to wait for the user.
- *   - `writeOutputTool`  — appends/overwrites a PRD section.
- *   - `finalizeTool`     — closes the session.
+ *   Diagnostics / orchestration:
+ *     - `echoTool`         — diagnostic; replays its argument back to the LLM.
+ *     - `askQuestionTool`  — HITL pause; persists a Question and signals the
+ *                            loop to wait for the user.
+ *     - `writeOutputTool`  — appends/overwrites a PRD section.
+ *     - `finalizeTool`     — closes the session.
+ *
+ *   Research (slice 7 — see `./research.ts`):
+ *     - `webSearchTool`         — Brave Search.
+ *     - `searchLibraryDocsTool` — Context7 public API.
+ *     - `readUrlTool`           — generic URL → readable text.
  *
  * Each tool's input shape is an Effect Schema so the dispatcher can
  * decode raw JSON arguments before `execute` runs. The Schemas are also
@@ -24,6 +30,7 @@ import {
   WroteOutput,
 } from '~/shared/infra/ai/tool'
 import { SessionContext } from './catalog'
+import { researchTools } from './research'
 
 /* ------------------------------------------------------------------ *
  * echo
@@ -130,4 +137,5 @@ export const builtinTools = [
   askQuestionTool,
   writeOutputTool,
   finalizeTool,
+  ...researchTools,
 ] as const

--- a/src/shared/agent/tools/research.test.ts
+++ b/src/shared/agent/tools/research.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Research tool dispatch tests.
+ *
+ * The three Research Tools (`webSearch`, `searchLibraryDocs`, `readUrl`) are
+ * thin wrappers over the corresponding seam services. Tests dispatch through
+ * the catalog (matching how the Loop does it in production) and provide
+ * canned-response Stub layers for each external service.
+ *
+ * What we're asserting here:
+ *   1. The catalog accepts the tool by name.
+ *   2. The tool's Schema decoding accepts the LLM-shaped JSON args.
+ *   3. The tool produces a `Continue(payload)` outcome with the expected
+ *      structured shape — that's what gets streamed back as `tool_result`.
+ */
+import { describe, it, expect } from '@effect/vitest'
+import { Effect, Layer } from 'effect'
+import { BraveSearch, BraveStub } from '~/shared/infra/brave/client'
+import { Context7, Context7Stub } from '~/shared/infra/context7/client'
+import {
+  UrlFetcher,
+  UrlFetcherStub,
+} from '~/shared/infra/url-fetcher/client'
+import { makeCatalog } from './catalog'
+import { researchTools } from './research'
+
+/**
+ * Bundles the canned-response layers for every research seam together,
+ * so each dispatch test can provide them in one line. Tests that only
+ * exercise one tool don't pay for the others — empty stubs are cheap.
+ */
+const stubs = (overrides?: {
+  readonly brave?: Parameters<typeof BraveStub.layer>[0]
+  readonly context7?: Parameters<typeof Context7Stub.layer>[0]
+  readonly urlFetcher?: Parameters<typeof UrlFetcherStub.layer>[0]
+}): Layer.Layer<BraveSearch | Context7 | UrlFetcher> =>
+  Layer.mergeAll(
+    BraveStub.layer(overrides?.brave ?? []),
+    Context7Stub.layer(overrides?.context7 ?? {}),
+    UrlFetcherStub.layer(overrides?.urlFetcher ?? []),
+  )
+
+describe('webSearch tool', () => {
+  it.effect('dispatches through the catalog and returns Continue with results', () =>
+    Effect.gen(function* () {
+      const catalog = makeCatalog(researchTools)
+      const outcome = yield* catalog.dispatch({
+        name: 'webSearch',
+        rawArguments: JSON.stringify({ query: 'effect typescript' }),
+      })
+
+      if (outcome._tag !== 'Continue') {
+        throw new Error(`expected Continue, got ${outcome._tag}`)
+      }
+      expect(outcome.result).toEqual({
+        results: [
+          {
+            title: 'Effect-TS docs',
+            url: 'https://effect.website/',
+            snippet: 'Robust TypeScript apps.',
+          },
+        ],
+      })
+    }).pipe(
+      Effect.provide(
+        stubs({
+          brave: [
+            {
+              results: [
+                {
+                  title: 'Effect-TS docs',
+                  url: 'https://effect.website/',
+                  snippet: 'Robust TypeScript apps.',
+                },
+              ],
+            },
+          ],
+        }),
+      ),
+    ),
+  )
+})
+
+describe('searchLibraryDocs tool', () => {
+  it.effect('chains library search + context fetch and returns Continue with snippets', () =>
+    Effect.gen(function* () {
+      const catalog = makeCatalog(researchTools)
+      const outcome = yield* catalog.dispatch({
+        name: 'searchLibraryDocs',
+        rawArguments: JSON.stringify({
+          library: 'next.js',
+          query: 'route handlers',
+        }),
+      })
+
+      if (outcome._tag !== 'Continue') {
+        throw new Error(`expected Continue, got ${outcome._tag}`)
+      }
+      expect(outcome.result).toEqual({
+        library: 'next.js',
+        libraryId: '/vercel/next.js',
+        title: 'Next.js',
+        snippets: [
+          { title: 'Routing', content: 'App Router intro.' },
+          { title: 'Handler', content: 'export async function GET() {}' },
+        ],
+      })
+    }).pipe(
+      Effect.provide(
+        stubs({
+          context7: {
+            libraries: [{ libraryId: '/vercel/next.js', title: 'Next.js' }],
+            contexts: [
+              [
+                { title: 'Routing', content: 'App Router intro.' },
+                { title: 'Handler', content: 'export async function GET() {}' },
+              ],
+            ],
+          },
+        }),
+      ),
+    ),
+  )
+})
+
+describe('readUrl tool', () => {
+  it.effect('dispatches through the catalog and returns Continue with extracted content', () =>
+    Effect.gen(function* () {
+      const catalog = makeCatalog(researchTools)
+      const outcome = yield* catalog.dispatch({
+        name: 'readUrl',
+        rawArguments: JSON.stringify({ url: 'https://example.com/article' }),
+      })
+
+      if (outcome._tag !== 'Continue') {
+        throw new Error(`expected Continue, got ${outcome._tag}`)
+      }
+      expect(outcome.result).toEqual({
+        url: 'https://example.com/article',
+        content: 'The article body.',
+      })
+    }).pipe(
+      Effect.provide(
+        stubs({
+          urlFetcher: [
+            {
+              url: 'https://example.com/article',
+              content: 'The article body.',
+            },
+          ],
+        }),
+      ),
+    ),
+  )
+})

--- a/src/shared/agent/tools/research.ts
+++ b/src/shared/agent/tools/research.ts
@@ -1,0 +1,102 @@
+/**
+ * Research tools — the three external-research wrappers the Agent Loop
+ * uses to ground its recommendations.
+ *
+ *   - `webSearch(query, count?)`         — Brave Search
+ *   - `searchLibraryDocs(library, query)` — Context7 public API
+ *   - `readUrl(url)`                      — generic URL → readable text
+ *
+ * Each is a thin wrapper over an `infra/*` seam service. The Schemas are
+ * what the LLM sees as the tool's JSON Schema; the `execute` body delegates
+ * the entire HTTP / parsing concern to the seam, and emits `Continue(...)`
+ * so the Loop streams a `tool_result` event back to the user.
+ */
+import { Effect, Schema } from 'effect'
+import { BraveSearch } from '~/shared/infra/brave/client'
+import { Context7 } from '~/shared/infra/context7/client'
+import { UrlFetcher } from '~/shared/infra/url-fetcher/client'
+import { Continue, defineTool } from '~/shared/infra/ai/tool'
+
+/* ------------------------------------------------------------------ *
+ * webSearch
+ * ------------------------------------------------------------------ */
+
+const WebSearchInput = Schema.Struct({
+  query: Schema.String,
+  count: Schema.optional(Schema.Number),
+})
+
+export const webSearchTool = defineTool({
+  name: 'webSearch',
+  description:
+    'Search the public web via Brave. Use this to find sources, recent news, or general background before recommending an answer. Returns up to N results, each with title, url, and snippet.',
+  inputSchema: WebSearchInput,
+  execute: (input) =>
+    Effect.gen(function* () {
+      const brave = yield* BraveSearch
+      const res = yield* brave.search({
+        query: input.query,
+        count: input.count,
+      })
+      return Continue({ results: res.results })
+    }),
+})
+
+/* ------------------------------------------------------------------ *
+ * searchLibraryDocs
+ * ------------------------------------------------------------------ */
+
+const SearchLibraryDocsInput = Schema.Struct({
+  library: Schema.String,
+  query: Schema.String,
+})
+
+export const searchLibraryDocsTool = defineTool({
+  name: 'searchLibraryDocs',
+  description:
+    "Find current documentation excerpts for a named library (e.g. 'next.js', 'react', 'effect') filtered by a topic query. Returns top excerpts as snippets.",
+  inputSchema: SearchLibraryDocsInput,
+  execute: (input) =>
+    Effect.gen(function* () {
+      const c7 = yield* Context7
+      const lib = yield* c7.searchLibrary(input.library)
+      const snippets = yield* c7.fetchContext(lib.libraryId, input.query)
+      return Continue({
+        library: input.library,
+        libraryId: lib.libraryId,
+        title: lib.title,
+        snippets,
+      })
+    }),
+})
+
+/* ------------------------------------------------------------------ *
+ * readUrl
+ * ------------------------------------------------------------------ */
+
+const ReadUrlInput = Schema.Struct({
+  url: Schema.String,
+})
+
+export const readUrlTool = defineTool({
+  name: 'readUrl',
+  description:
+    'Fetch a URL and return its readable text. Use this on a result from webSearch when you need more than the snippet to answer a user question.',
+  inputSchema: ReadUrlInput,
+  execute: (input) =>
+    Effect.gen(function* () {
+      const fetcher = yield* UrlFetcher
+      const out = yield* fetcher.fetchReadable(input.url)
+      return Continue({ url: out.url, content: out.content })
+    }),
+})
+
+/* ------------------------------------------------------------------ *
+ * Catalogue contents
+ * ------------------------------------------------------------------ */
+
+export const researchTools = [
+  webSearchTool,
+  searchLibraryDocsTool,
+  readUrlTool,
+] as const

--- a/src/shared/domain/errors.ts
+++ b/src/shared/domain/errors.ts
@@ -91,6 +91,90 @@ export type GroqError =
   | GroqEmptyCompletionError
 
 /* ------------------------------------------------------------------ *
+ * Brave Search
+ * ------------------------------------------------------------------ */
+
+export class BraveAuthError extends Data.TaggedError('BraveAuthError')<{
+  readonly reason: string
+}> {}
+
+export class BraveNetworkError extends Data.TaggedError('BraveNetworkError')<{
+  readonly cause: unknown
+}> {}
+
+export class BraveRateLimitError extends Data.TaggedError(
+  'BraveRateLimitError',
+)<{
+  readonly retryAfterSeconds?: number
+}> {}
+
+export class BraveApiError extends Data.TaggedError('BraveApiError')<{
+  readonly status: number
+  readonly body: string
+}> {}
+
+export type BraveError =
+  | BraveAuthError
+  | BraveNetworkError
+  | BraveRateLimitError
+  | BraveApiError
+
+/* ------------------------------------------------------------------ *
+ * Context7
+ * ------------------------------------------------------------------ */
+
+export class Context7NetworkError extends Data.TaggedError(
+  'Context7NetworkError',
+)<{
+  readonly cause: unknown
+}> {}
+
+export class Context7ApiError extends Data.TaggedError('Context7ApiError')<{
+  readonly status: number
+  readonly body: string
+}> {}
+
+export class Context7NotFound extends Data.TaggedError('Context7NotFound')<{
+  readonly query: string
+}> {}
+
+export type Context7Error =
+  | Context7NetworkError
+  | Context7ApiError
+  | Context7NotFound
+
+/* ------------------------------------------------------------------ *
+ * URL fetcher (readUrl)
+ * ------------------------------------------------------------------ */
+
+export class UrlFetcherTimeout extends Data.TaggedError('UrlFetcherTimeout')<{
+  readonly url: string
+}> {}
+
+export class UrlFetcherTooLarge extends Data.TaggedError('UrlFetcherTooLarge')<{
+  readonly url: string
+  readonly bytes: number
+}> {}
+
+export class UrlFetcherHttpError extends Data.TaggedError('UrlFetcherHttpError')<{
+  readonly url: string
+  readonly status: number
+}> {}
+
+export class UrlFetcherNetworkError extends Data.TaggedError(
+  'UrlFetcherNetworkError',
+)<{
+  readonly url: string
+  readonly cause: unknown
+}> {}
+
+export type UrlFetcherError =
+  | UrlFetcherTimeout
+  | UrlFetcherTooLarge
+  | UrlFetcherHttpError
+  | UrlFetcherNetworkError
+
+/* ------------------------------------------------------------------ *
  * Tools
  * ------------------------------------------------------------------ */
 
@@ -164,7 +248,13 @@ export type RequestParseError = JsonSyntaxError | SchemaViolation
  * Agent Loop — union of everything the loop can fail with.
  * ------------------------------------------------------------------ */
 
-export type LoopError = GroqError | ToolError | RepositoryError
+export type LoopError =
+  | GroqError
+  | ToolError
+  | RepositoryError
+  | BraveError
+  | Context7Error
+  | UrlFetcherError
 
 /* ------------------------------------------------------------------ *
  * HTTP status mapping
@@ -181,6 +271,9 @@ export type AppError =
   | RequestParseError
   | NotFound
   | Conflict
+  | BraveError
+  | Context7Error
+  | UrlFetcherError
 
 export const statusForError = (e: AppError): number => {
   switch (e._tag) {
@@ -200,12 +293,26 @@ export const statusForError = (e: AppError): number => {
     case 'GroqAuthError':
       return 502
     case 'GroqRateLimitError':
+    case 'BraveRateLimitError':
       return 429
     case 'GroqNetworkError':
     case 'GroqApiError':
     case 'GroqParseError':
     case 'GroqEmptyCompletionError':
+    case 'BraveAuthError':
+    case 'BraveNetworkError':
+    case 'BraveApiError':
+    case 'Context7NetworkError':
+    case 'Context7ApiError':
+    case 'UrlFetcherNetworkError':
+    case 'UrlFetcherHttpError':
       return 502
+    case 'Context7NotFound':
+      return 404
+    case 'UrlFetcherTimeout':
+      return 504
+    case 'UrlFetcherTooLarge':
+      return 413
     case 'ToolExecutionError':
     case 'RepositoryRowDecodeError':
     case 'RepositoryUnknownError':

--- a/src/shared/infra/brave/client.test.ts
+++ b/src/shared/infra/brave/client.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests for the `BraveSearch` Effect service.
+ *
+ *   - `BraveLive(opts)` is the live layer; we drive it with a `fetch` stub so
+ *     the live HTTP transport never opens a real socket.
+ *   - The wire shape is asserted on (URL, header, query string).
+ *   - Response is parsed into `{ results: [{title, url, snippet}, …] }` —
+ *     mapping Brave's `web.results[].description` onto our `snippet`.
+ */
+import { describe, it, expect } from '@effect/vitest'
+import { Cause, Effect, Exit } from 'effect'
+import { BRAVE_BASE_URL, BraveSearch, BraveLive } from './client'
+
+interface CapturedRequest {
+  readonly url: string
+  readonly init: RequestInit
+}
+
+const fetchStub = (
+  body: object,
+  status: number,
+  captured: { current: CapturedRequest | null },
+  headers?: Record<string, string>,
+): typeof fetch =>
+  (async (input: RequestInfo | URL, init?: RequestInit) => {
+    captured.current = {
+      url: typeof input === 'string' ? input : input.toString(),
+      init: init ?? {},
+    }
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { 'content-type': 'application/json', ...(headers ?? {}) },
+    })
+  }) as typeof fetch
+
+describe('BraveLive', () => {
+  it.effect('GETs the Brave web/search endpoint with the API key header and parses results', () =>
+    Effect.gen(function* () {
+      const captured: { current: CapturedRequest | null } = { current: null }
+      const layer = BraveLive({
+        apiKey: 'test-key',
+        fetch: fetchStub(
+          {
+            web: {
+              results: [
+                {
+                  title: 'Effect-TS docs',
+                  url: 'https://effect.website/',
+                  description: 'The TypeScript library for building robust apps.',
+                },
+                {
+                  title: 'GitHub: Effect',
+                  url: 'https://github.com/Effect-TS/effect',
+                  description: 'Source for the Effect library.',
+                },
+              ],
+            },
+          },
+          200,
+          captured,
+        ),
+      })
+
+      const program = Effect.gen(function* () {
+        const brave = yield* BraveSearch
+        return yield* brave.search({ query: 'effect typescript', count: 5 })
+      })
+
+      const res = yield* program.pipe(Effect.provide(layer))
+
+      expect(res.results).toEqual([
+        {
+          title: 'Effect-TS docs',
+          url: 'https://effect.website/',
+          snippet: 'The TypeScript library for building robust apps.',
+        },
+        {
+          title: 'GitHub: Effect',
+          url: 'https://github.com/Effect-TS/effect',
+          snippet: 'Source for the Effect library.',
+        },
+      ])
+
+      expect(captured.current).not.toBeNull()
+      const { url, init } = captured.current!
+      expect(url).toContain(BRAVE_BASE_URL)
+      expect(url).toContain('q=effect+typescript')
+      expect(url).toContain('count=5')
+      const headers = new Headers(init.headers)
+      expect(headers.get('x-subscription-token')).toBe('test-key')
+      expect(headers.get('accept')).toBe('application/json')
+      // Brave is GET — no body.
+      expect(init.method ?? 'GET').toBe('GET')
+    }),
+  )
+
+  it.effect('classifies 429 as BraveRateLimitError with retryAfterSeconds', () =>
+    Effect.gen(function* () {
+      const captured: { current: CapturedRequest | null } = { current: null }
+      const layer = BraveLive({
+        apiKey: 'k',
+        fetch: fetchStub({}, 429, captured, { 'retry-after': '17' }),
+      })
+      const program = Effect.gen(function* () {
+        const brave = yield* BraveSearch
+        return yield* brave.search({ query: 'q' })
+      })
+      const exit = yield* Effect.exit(program.pipe(Effect.provide(layer)))
+      expect(Exit.isFailure(exit)).toBe(true)
+      if (Exit.isFailure(exit)) {
+        const failure = Cause.failureOption(exit.cause)
+        expect(failure._tag).toBe('Some')
+        if (failure._tag === 'Some') {
+          expect(failure.value._tag).toBe('BraveRateLimitError')
+          if (failure.value._tag === 'BraveRateLimitError') {
+            expect(failure.value.retryAfterSeconds).toBe(17)
+          }
+        }
+      }
+    }),
+  )
+
+  it.effect('fails with BraveAuthError when apiKey is missing', () =>
+    Effect.gen(function* () {
+      const layer = BraveLive({ apiKey: undefined })
+      const program = Effect.gen(function* () {
+        const brave = yield* BraveSearch
+        return yield* brave.search({ query: 'x' })
+      })
+      const exit = yield* Effect.exit(program.pipe(Effect.provide(layer)))
+      expect(Exit.isFailure(exit)).toBe(true)
+      if (Exit.isFailure(exit)) {
+        const failure = Cause.failureOption(exit.cause)
+        expect(failure._tag).toBe('Some')
+        if (failure._tag === 'Some') {
+          expect(failure.value._tag).toBe('BraveAuthError')
+        }
+      }
+    }),
+  )
+})

--- a/src/shared/infra/brave/client.ts
+++ b/src/shared/infra/brave/client.ts
@@ -1,0 +1,172 @@
+/**
+ * `BraveSearch` — Effect service for the Brave Search API seam.
+ *
+ * The seam exists so the `webSearch` tool can hand off "find me top results
+ * for query X" to a swappable adapter. Live talks to Brave via `fetch`;
+ * tests provide either a stubbed `fetch` (this file's `BraveLive` tests) or
+ * a canned `BraveStub.layer` (consumers that don't care about wire shape).
+ *
+ * Auth: `X-Subscription-Token: <BRAVE_API_KEY>` header. Missing key fails
+ * the layer build with `BraveAuthError` rather than letting the request
+ * 401 at runtime.
+ *
+ * Wire shape (what the tool wraps):
+ *
+ *   GET https://api.search.brave.com/res/v1/web/search?q=<query>&count=<n>
+ *   Accept: application/json
+ *   X-Subscription-Token: <key>
+ *
+ *   {
+ *     "web": { "results": [{ "title": ..., "url": ..., "description": ... }] }
+ *   }
+ *
+ * The service flattens that into `{ results: [{title, url, snippet}] }` —
+ * `description` is renamed to `snippet` to match the agent's expectations.
+ */
+import { Context, Effect, Layer, Ref } from 'effect'
+import {
+  type BraveError,
+  BraveApiError,
+  BraveAuthError,
+  BraveNetworkError,
+  BraveRateLimitError,
+} from '~/shared/domain/errors'
+
+export const BRAVE_BASE_URL = 'https://api.search.brave.com/res/v1/web/search'
+
+export interface BraveSearchParams {
+  readonly query: string
+  /** Top-N results to return; Brave caps at 20. Default 5. */
+  readonly count?: number
+}
+
+export interface BraveSearchResult {
+  readonly title: string
+  readonly url: string
+  readonly snippet: string
+}
+
+export interface BraveSearchResponse {
+  readonly results: ReadonlyArray<BraveSearchResult>
+}
+
+export class BraveSearch extends Context.Tag('BraveSearch')<
+  BraveSearch,
+  {
+    readonly search: (
+      params: BraveSearchParams,
+    ) => Effect.Effect<BraveSearchResponse, BraveError>
+  }
+>() {}
+
+export interface BraveLiveOptions {
+  readonly apiKey: string | undefined
+  readonly baseURL?: string
+  readonly fetch?: typeof fetch
+}
+
+interface BraveRawResponse {
+  readonly web?: {
+    readonly results?: ReadonlyArray<{
+      readonly title?: string
+      readonly url?: string
+      readonly description?: string
+    }>
+  }
+}
+
+const DEFAULT_COUNT = 5
+
+export const BraveLive = (
+  options: BraveLiveOptions,
+): Layer.Layer<BraveSearch> =>
+  Layer.succeed(BraveSearch, {
+    search: (params) =>
+      Effect.gen(function* () {
+        if (!options.apiKey) {
+          return yield* new BraveAuthError({
+            reason: 'BRAVE_API_KEY is required to call Brave Search',
+          })
+        }
+
+        const baseURL = options.baseURL ?? BRAVE_BASE_URL
+        const fetchImpl = options.fetch ?? fetch
+        const count = params.count ?? DEFAULT_COUNT
+
+        const url = `${baseURL}?q=${encodeURIComponent(params.query).replace(/%20/g, '+')}&count=${count}`
+        const headers = new Headers({
+          accept: 'application/json',
+          'x-subscription-token': options.apiKey,
+        })
+
+        const res = yield* Effect.tryPromise({
+          try: () => fetchImpl(url, { method: 'GET', headers }),
+          catch: (cause): BraveError => new BraveNetworkError({ cause }),
+        })
+
+        if (res.status === 401 || res.status === 403) {
+          return yield* new BraveAuthError({
+            reason: `Brave returned ${res.status}`,
+          })
+        }
+        if (res.status === 429) {
+          const ra = res.headers.get('retry-after')
+          const seconds =
+            ra !== null && ra.length > 0 ? Number(ra) : undefined
+          return yield* new BraveRateLimitError({
+            retryAfterSeconds: Number.isFinite(seconds) ? seconds : undefined,
+          })
+        }
+        if (!res.ok) {
+          const body = yield* Effect.tryPromise({
+            try: () => res.text(),
+            catch: () => new BraveApiError({ status: res.status, body: '' }),
+          }).pipe(Effect.orElseSucceed(() => ''))
+          return yield* new BraveApiError({ status: res.status, body })
+        }
+
+        const json = (yield* Effect.tryPromise({
+          try: () => res.json() as Promise<BraveRawResponse>,
+          catch: (cause): BraveError => new BraveNetworkError({ cause }),
+        })) as BraveRawResponse
+
+        const results = (json.web?.results ?? []).map((r) => ({
+          title: r.title ?? '',
+          url: r.url ?? '',
+          snippet: r.description ?? '',
+        }))
+
+        return { results }
+      }),
+  })
+
+/**
+ * Test adapter: returns canned `BraveSearchResponse`s in order. After the
+ * list is exhausted, further calls fail with `BraveApiError`. Provide via
+ * `Layer.provide(BraveStub.layer([...]))` in `it.effect`.
+ */
+export const BraveStub = {
+  layer: (
+    responses: ReadonlyArray<BraveSearchResponse>,
+  ): Layer.Layer<BraveSearch> =>
+    Layer.scoped(
+      BraveSearch,
+      Effect.gen(function* () {
+        const cursor = yield* Ref.make(0)
+        return BraveSearch.of({
+          search: () =>
+            Effect.gen(function* () {
+              const i = yield* Ref.modify(cursor, (n) => [n, n + 1])
+              const r = responses[i]
+              if (!r) {
+                return yield* new BraveApiError({
+                  status: 0,
+                  body: `BraveStub: no canned response for call ${i + 1}`,
+                })
+              }
+              return r
+            }),
+        })
+      }),
+    ),
+}

--- a/src/shared/infra/context7/client.test.ts
+++ b/src/shared/infra/context7/client.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Tests for the `Context7` Effect service.
+ *
+ * Context7 has a public v1 endpoint that doesn't require an API key. The
+ * `searchDocs` operation is a two-step orchestration: search the library
+ * catalogue, then fetch context for the top hit. Tests stub `fetch` and
+ * assert on the wire shape of *both* calls plus the merged response.
+ */
+import { describe, it, expect } from '@effect/vitest'
+import { Effect } from 'effect'
+import { CONTEXT7_BASE_URL, Context7, Context7Live } from './client'
+
+interface Captured {
+  readonly url: string
+  readonly init: RequestInit
+}
+
+const sequencedFetch = (
+  responses: ReadonlyArray<{
+    readonly status: number
+    readonly body: unknown
+  }>,
+  log: Array<Captured>,
+): typeof fetch =>
+  (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const i = log.length
+    log.push({
+      url: typeof input === 'string' ? input : input.toString(),
+      init: init ?? {},
+    })
+    const turn = responses[i]
+    if (!turn) throw new Error(`no canned response for call ${i + 1}`)
+    return new Response(JSON.stringify(turn.body), {
+      status: turn.status,
+      headers: { 'content-type': 'application/json' },
+    })
+  }) as typeof fetch
+
+describe('Context7Live.searchLibrary', () => {
+  it.effect('GETs /api/v1/search?query=<name> and returns the top library id and title', () =>
+    Effect.gen(function* () {
+      const log: Array<Captured> = []
+      const layer = Context7Live({
+        fetch: sequencedFetch(
+          [
+            {
+              status: 200,
+              body: {
+                results: [
+                  {
+                    id: '/vercel/next.js',
+                    title: 'Next.js',
+                    description: 'The React Framework',
+                    trustScore: 9.5,
+                  },
+                  {
+                    id: '/react/docs',
+                    title: 'React',
+                    description: 'A library',
+                    trustScore: 9.4,
+                  },
+                ],
+              },
+            },
+          ],
+          log,
+        ),
+      })
+
+      const program = Effect.gen(function* () {
+        const c7 = yield* Context7
+        return yield* c7.searchLibrary('next.js')
+      })
+
+      const res = yield* program.pipe(Effect.provide(layer))
+      expect(res.libraryId).toBe('/vercel/next.js')
+      expect(res.title).toBe('Next.js')
+
+      expect(log).toHaveLength(1)
+      expect(log[0]!.url).toContain(CONTEXT7_BASE_URL)
+      expect(log[0]!.url).toContain('/search?query=next.js')
+    }),
+  )
+
+  it.effect('returns Context7NotFound when search yields zero results', () =>
+    Effect.gen(function* () {
+      const log: Array<Captured> = []
+      const layer = Context7Live({
+        fetch: sequencedFetch([{ status: 200, body: { results: [] } }], log),
+      })
+      const program = Effect.gen(function* () {
+        const c7 = yield* Context7
+        return yield* c7.searchLibrary('totally-fake-lib')
+      })
+      const exit = yield* Effect.exit(program.pipe(Effect.provide(layer)))
+      if (exit._tag !== 'Failure') throw new Error('expected failure')
+    }),
+  )
+})
+
+describe('Context7Live.fetchContext', () => {
+  it.effect('GETs /api/v1/<libraryId>?topic=<query> and flattens snippets', () =>
+    Effect.gen(function* () {
+      const log: Array<Captured> = []
+      const layer = Context7Live({
+        fetch: sequencedFetch(
+          [
+            {
+              status: 200,
+              body: {
+                infoSnippets: [
+                  { title: 'Routing', content: 'Use App Router for ...' },
+                ],
+                codeSnippets: [
+                  {
+                    codeTitle: 'Route handler',
+                    codeList: [
+                      { code: 'export async function GET() {}' },
+                      { code: 'export async function POST() {}' },
+                    ],
+                  },
+                ],
+              },
+            },
+          ],
+          log,
+        ),
+      })
+
+      const program = Effect.gen(function* () {
+        const c7 = yield* Context7
+        return yield* c7.fetchContext('/vercel/next.js', 'route handlers')
+      })
+
+      const snippets = yield* program.pipe(Effect.provide(layer))
+      // info snippets first, then flattened code snippets — order matters for the agent.
+      expect(snippets.map((s) => s.content)).toEqual([
+        'Use App Router for ...',
+        'export async function GET() {}',
+        'export async function POST() {}',
+      ])
+
+      expect(log).toHaveLength(1)
+      expect(log[0]!.url).toContain('/vercel/next.js')
+      expect(log[0]!.url).toContain('topic=route%20handlers')
+      expect(log[0]!.url).toContain('type=json')
+    }),
+  )
+})

--- a/src/shared/infra/context7/client.ts
+++ b/src/shared/infra/context7/client.ts
@@ -1,0 +1,169 @@
+/**
+ * `Context7` — Effect service for the Context7 public v1 API.
+ *
+ * No API key required for the public endpoint. Two operations:
+ *
+ *   - `searchLibrary(name)`         → top match `{ libraryId, title }`
+ *   - `fetchContext(libraryId, q)`  → snippet excerpts for that library
+ *
+ * The `searchLibraryDocs` tool chains both. Failures are typed via
+ * `Context7Error`. A search that returns zero results is `Context7NotFound`
+ * — the tool should surface this to the LLM so it can ask for a different
+ * library name rather than silently producing empty context.
+ */
+import { Context, Effect, Layer, Ref } from 'effect'
+import {
+  type Context7Error,
+  Context7ApiError,
+  Context7NetworkError,
+  Context7NotFound,
+} from '~/shared/domain/errors'
+
+export const CONTEXT7_BASE_URL = 'https://context7.com/api/v1'
+
+export interface Context7Library {
+  readonly libraryId: string
+  readonly title: string
+}
+
+export interface Context7Snippet {
+  readonly title: string
+  readonly content: string
+}
+
+export class Context7 extends Context.Tag('Context7')<
+  Context7,
+  {
+    readonly searchLibrary: (
+      name: string,
+    ) => Effect.Effect<Context7Library, Context7Error>
+    readonly fetchContext: (
+      libraryId: string,
+      query: string,
+    ) => Effect.Effect<ReadonlyArray<Context7Snippet>, Context7Error>
+  }
+>() {}
+
+export interface Context7LiveOptions {
+  readonly baseURL?: string
+  readonly fetch?: typeof fetch
+}
+
+interface SearchRaw {
+  readonly results?: ReadonlyArray<{
+    readonly id?: string
+    readonly title?: string
+  }>
+}
+
+interface ContextRaw {
+  readonly codeSnippets?: ReadonlyArray<{
+    readonly codeTitle?: string
+    readonly codeList?: ReadonlyArray<{ readonly code?: string }>
+  }>
+  readonly infoSnippets?: ReadonlyArray<{
+    readonly content?: string
+    readonly title?: string
+  }>
+}
+
+const requestJson = (
+  fetchImpl: typeof fetch,
+  url: string,
+): Effect.Effect<unknown, Context7Error> =>
+  Effect.gen(function* () {
+    const res = yield* Effect.tryPromise({
+      try: () =>
+        fetchImpl(url, {
+          method: 'GET',
+          headers: { accept: 'application/json' },
+        }),
+      catch: (cause): Context7Error => new Context7NetworkError({ cause }),
+    })
+
+    if (!res.ok) {
+      const body = yield* Effect.tryPromise({
+        try: () => res.text(),
+        catch: () => new Context7ApiError({ status: res.status, body: '' }),
+      }).pipe(Effect.orElseSucceed(() => ''))
+      return yield* new Context7ApiError({ status: res.status, body })
+    }
+
+    return yield* Effect.tryPromise({
+      try: () => res.json() as Promise<unknown>,
+      catch: (cause): Context7Error => new Context7NetworkError({ cause }),
+    })
+  })
+
+export const Context7Live = (
+  options: Context7LiveOptions = {},
+): Layer.Layer<Context7> =>
+  Layer.succeed(Context7, {
+    searchLibrary: (name) =>
+      Effect.gen(function* () {
+        const baseURL = options.baseURL ?? CONTEXT7_BASE_URL
+        const fetchImpl = options.fetch ?? fetch
+        const url = `${baseURL}/search?query=${encodeURIComponent(name)}`
+        const raw = (yield* requestJson(fetchImpl, url)) as SearchRaw
+        const top = raw.results?.[0]
+        if (!top || !top.id) {
+          return yield* new Context7NotFound({ query: name })
+        }
+        return { libraryId: top.id, title: top.title ?? top.id }
+      }),
+    fetchContext: (libraryId, query) =>
+      Effect.gen(function* () {
+        const baseURL = options.baseURL ?? CONTEXT7_BASE_URL
+        const fetchImpl = options.fetch ?? fetch
+        const url = `${baseURL}${libraryId}?topic=${encodeURIComponent(query)}&type=json`
+        const raw = (yield* requestJson(fetchImpl, url)) as ContextRaw
+
+        const code = (raw.codeSnippets ?? []).flatMap((cs) =>
+          (cs.codeList ?? []).map((c) => ({
+            title: cs.codeTitle ?? '',
+            content: c.code ?? '',
+          })),
+        )
+        const info = (raw.infoSnippets ?? []).map((s) => ({
+          title: s.title ?? '',
+          content: s.content ?? '',
+        }))
+
+        return [...info, ...code]
+      }),
+  })
+
+/**
+ * Test adapter — canned `searchLibrary` and `fetchContext` results.
+ */
+export const Context7Stub = {
+  layer: (canned: {
+    readonly libraries?: ReadonlyArray<Context7Library>
+    readonly contexts?: ReadonlyArray<ReadonlyArray<Context7Snippet>>
+  }): Layer.Layer<Context7> =>
+    Layer.scoped(
+      Context7,
+      Effect.gen(function* () {
+        const libIdx = yield* Ref.make(0)
+        const ctxIdx = yield* Ref.make(0)
+        const libs = canned.libraries ?? []
+        const ctxs = canned.contexts ?? []
+        return Context7.of({
+          searchLibrary: (name) =>
+            Effect.gen(function* () {
+              const i = yield* Ref.modify(libIdx, (n) => [n, n + 1])
+              const lib = libs[i]
+              if (!lib) {
+                return yield* new Context7NotFound({ query: name })
+              }
+              return lib
+            }),
+          fetchContext: () =>
+            Effect.gen(function* () {
+              const i = yield* Ref.modify(ctxIdx, (n) => [n, n + 1])
+              return ctxs[i] ?? []
+            }),
+        })
+      }),
+    ),
+}

--- a/src/shared/infra/url-fetcher/client.test.ts
+++ b/src/shared/infra/url-fetcher/client.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Tests for the `UrlFetcher` Effect service.
+ *
+ * The fetcher GETs a URL and returns extracted readable text. v1 strips HTML
+ * tags and collapses whitespace — no fancy readability extraction. The seam
+ * exists so the `readUrl` tool can hand off "give me the text of <url>"
+ * without owning timeout / size-guard / extraction logic.
+ */
+import { describe, it, expect } from '@effect/vitest'
+import { Cause, Effect, Exit, TestClock } from 'effect'
+import { UrlFetcher, UrlFetcherLive } from './client'
+
+interface Captured {
+  readonly url: string
+  readonly init: RequestInit
+}
+
+const fetchStub = (
+  body: string,
+  status: number,
+  log: { current: Captured | null },
+  contentType = 'text/html',
+): typeof fetch =>
+  (async (input: RequestInfo | URL, init?: RequestInit) => {
+    log.current = {
+      url: typeof input === 'string' ? input : input.toString(),
+      init: init ?? {},
+    }
+    return new Response(body, {
+      status,
+      headers: { 'content-type': contentType },
+    })
+  }) as typeof fetch
+
+describe('UrlFetcherLive.fetchReadable', () => {
+  it.effect('GETs the URL and returns plain text with HTML stripped', () =>
+    Effect.gen(function* () {
+      const log: { current: Captured | null } = { current: null }
+      const layer = UrlFetcherLive({
+        fetch: fetchStub(
+          '<html><body><h1>Hello</h1><p>This is a <a href="x">link</a> and <strong>bold</strong> text.</p><script>alert(1)</script></body></html>',
+          200,
+          log,
+        ),
+      })
+
+      const program = Effect.gen(function* () {
+        const f = yield* UrlFetcher
+        return yield* f.fetchReadable('https://example.com/article')
+      })
+
+      const out = yield* program.pipe(Effect.provide(layer))
+      expect(out.url).toBe('https://example.com/article')
+      // Tags stripped, whitespace collapsed, scripts dropped.
+      expect(out.content).toBe('Hello This is a link and bold text.')
+      expect(log.current?.url).toBe('https://example.com/article')
+    }),
+  )
+
+  it.effect('returns plain text bodies unchanged (whitespace-collapsed)', () =>
+    Effect.gen(function* () {
+      const log: { current: Captured | null } = { current: null }
+      const layer = UrlFetcherLive({
+        fetch: fetchStub(
+          'Line one.\n\nLine    two.\n\tLine\tthree.',
+          200,
+          log,
+          'text/plain',
+        ),
+      })
+      const program = Effect.gen(function* () {
+        const f = yield* UrlFetcher
+        return yield* f.fetchReadable('https://example.com/raw.txt')
+      })
+      const out = yield* program.pipe(Effect.provide(layer))
+      expect(out.content).toBe('Line one. Line two. Line three.')
+    }),
+  )
+
+  it.effect('fails with UrlFetcherTimeout when fetch never resolves', () =>
+    Effect.gen(function* () {
+      // Slow fetch — never resolves on its own.
+      const slowFetch = (() =>
+        new Promise<Response>(() => {
+          /* never */
+        })) as unknown as typeof fetch
+
+      const layer = UrlFetcherLive({
+        fetch: slowFetch,
+        timeoutMillis: 1_000,
+      })
+
+      const program = Effect.gen(function* () {
+        const f = yield* UrlFetcher
+        return yield* f.fetchReadable('https://slow.example/article')
+      })
+
+      // Drive the timeout deterministically via TestClock.
+      const fiber = yield* Effect.fork(
+        program.pipe(Effect.provide(layer), Effect.exit),
+      )
+      yield* TestClock.adjust('2 seconds')
+      const exit = yield* fiber.await
+
+      // Fiber.await wraps the exit; unwrap if needed.
+      const inner = exit._tag === 'Success' ? exit.value : exit
+      expect(Exit.isFailure(inner)).toBe(true)
+      if (Exit.isFailure(inner)) {
+        const failure = Cause.failureOption(inner.cause)
+        expect(failure._tag).toBe('Some')
+        if (failure._tag === 'Some') {
+          expect(failure.value._tag).toBe('UrlFetcherTimeout')
+        }
+      }
+    }),
+  )
+})

--- a/src/shared/infra/url-fetcher/client.ts
+++ b/src/shared/infra/url-fetcher/client.ts
@@ -1,0 +1,153 @@
+/**
+ * `UrlFetcher` — Effect service for the `readUrl` tool.
+ *
+ * Fetches a URL with a sane timeout, guards against oversize responses,
+ * and extracts readable text from the body. v1 extraction is deliberately
+ * dumb: strip `<script>` and `<style>` blocks, drop the rest of the tags,
+ * collapse whitespace. Good enough to feed back into the LLM as grounding
+ * for a recommendation; we can deepen later if real-world pages need it.
+ *
+ * Errors are typed:
+ *   - `UrlFetcherTimeout`     — request didn't complete in time
+ *   - `UrlFetcherTooLarge`    — response body exceeded `maxBytes`
+ *   - `UrlFetcherHttpError`   — non-2xx status
+ *   - `UrlFetcherNetworkError` — anything else (DNS, abort, etc.)
+ */
+import { Context, Effect, Layer, Ref } from 'effect'
+import {
+  type UrlFetcherError,
+  UrlFetcherHttpError,
+  UrlFetcherNetworkError,
+  UrlFetcherTimeout,
+  UrlFetcherTooLarge,
+} from '~/shared/domain/errors'
+
+export interface ReadableContent {
+  readonly url: string
+  readonly content: string
+}
+
+export class UrlFetcher extends Context.Tag('UrlFetcher')<
+  UrlFetcher,
+  {
+    readonly fetchReadable: (
+      url: string,
+    ) => Effect.Effect<ReadableContent, UrlFetcherError>
+  }
+>() {}
+
+export interface UrlFetcherLiveOptions {
+  readonly fetch?: typeof fetch
+  /** Default 10s. */
+  readonly timeoutMillis?: number
+  /** Default 1 MiB. Bodies above this fail with `UrlFetcherTooLarge`. */
+  readonly maxBytes?: number
+}
+
+const DEFAULT_TIMEOUT = 10_000
+const DEFAULT_MAX_BYTES = 1_000_000
+
+export const UrlFetcherLive = (
+  options: UrlFetcherLiveOptions = {},
+): Layer.Layer<UrlFetcher> =>
+  Layer.succeed(UrlFetcher, {
+    fetchReadable: (url) =>
+      Effect.gen(function* () {
+        const fetchImpl = options.fetch ?? fetch
+        const maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES
+
+        const res = yield* Effect.tryPromise({
+          try: () =>
+            fetchImpl(url, {
+              method: 'GET',
+              headers: { accept: 'text/html, text/plain;q=0.9, */*;q=0.5' },
+            }),
+          catch: (cause): UrlFetcherError =>
+            new UrlFetcherNetworkError({ url, cause }),
+        })
+
+        if (!res.ok) {
+          return yield* new UrlFetcherHttpError({ url, status: res.status })
+        }
+
+        const body = yield* Effect.tryPromise({
+          try: () => res.text(),
+          catch: (cause): UrlFetcherError =>
+            new UrlFetcherNetworkError({ url, cause }),
+        })
+
+        if (body.length > maxBytes) {
+          return yield* new UrlFetcherTooLarge({ url, bytes: body.length })
+        }
+
+        const contentType = res.headers.get('content-type') ?? ''
+        const content = contentType.includes('html')
+          ? extractFromHtml(body)
+          : collapseWhitespace(body)
+
+        return { url, content }
+      }).pipe(
+        Effect.timeoutFail({
+          duration: `${options.timeoutMillis ?? DEFAULT_TIMEOUT} millis`,
+          onTimeout: (): UrlFetcherError => new UrlFetcherTimeout({ url }),
+        }),
+      ),
+  })
+
+/* ------------------------------------------------------------------ *
+ * Extraction
+ *
+ * v1 algorithm:
+ *   1. drop `<script>` and `<style>` blocks (with their content)
+ *   2. drop the rest of the tags (keep their inner text)
+ *   3. decode the four entities we actually see (&amp; &lt; &gt; &quot;)
+ *   4. collapse whitespace
+ *
+ * Not perfect; deliberately not parsing HTML. If we need higher quality
+ * extraction (article body detection, link preservation, etc.) we can
+ * swap this out without changing the tool or the seam.
+ * ------------------------------------------------------------------ */
+
+const extractFromHtml = (html: string): string => {
+  const stripped = html
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+  return collapseWhitespace(stripped)
+}
+
+const collapseWhitespace = (s: string): string => s.replace(/\s+/g, ' ').trim()
+
+/**
+ * Test adapter — canned `ReadableContent`s in order. After the list is
+ * exhausted, further calls fail with `UrlFetcherNetworkError`.
+ */
+export const UrlFetcherStub = {
+  layer: (
+    responses: ReadonlyArray<ReadableContent>,
+  ): Layer.Layer<UrlFetcher> =>
+    Layer.scoped(
+      UrlFetcher,
+      Effect.gen(function* () {
+        const cursor = yield* Ref.make(0)
+        return UrlFetcher.of({
+          fetchReadable: (url) =>
+            Effect.gen(function* () {
+              const i = yield* Ref.modify(cursor, (n) => [n, n + 1])
+              const r = responses[i]
+              if (!r) {
+                return yield* new UrlFetcherNetworkError({
+                  url,
+                  cause: `UrlFetcherStub: no canned response for call ${i + 1}`,
+                })
+              }
+              return r
+            }),
+        })
+      }),
+    ),
+}

--- a/src/shared/runtime/main.ts
+++ b/src/shared/runtime/main.ts
@@ -6,6 +6,9 @@
  *   - `Ids`                  via `IdsLive` (web crypto)
  *   - `Groq`                 via `GroqLive`  (API key + retry + timeout)
  *   - `ResearchRepository`   via `RepositoryD1Live` (Drizzle on D1)
+ *   - `BraveSearch`          via `BraveLive` (Brave Search API)
+ *   - `Context7`             via `Context7Live` (public Context7 v1)
+ *   - `UrlFetcher`           via `UrlFetcherLive` (timeout + size guard)
  *
  * Per-request services (`EventStreamUrlBuilder`, `SessionContext`) are
  * NOT in here — those are provided fresh at the request boundary, where
@@ -23,20 +26,44 @@ import {
   ResearchRepository,
 } from '~/shared/infra/drizzle/repository'
 import { Groq, GroqLive, type GroqLiveOptions } from '~/shared/infra/groq/client'
+import {
+  BraveLive,
+  BraveSearch,
+  type BraveLiveOptions,
+} from '~/shared/infra/brave/client'
+import {
+  Context7,
+  Context7Live,
+  type Context7LiveOptions,
+} from '~/shared/infra/context7/client'
+import {
+  UrlFetcher,
+  UrlFetcherLive,
+  type UrlFetcherLiveOptions,
+} from '~/shared/infra/url-fetcher/client'
 import { EventStreamUrlBuilder } from '~/shared/research/session'
 
 export interface MainLiveOptions {
   readonly D1: D1Database
   readonly groq: GroqLiveOptions
+  readonly brave?: BraveLiveOptions
+  readonly context7?: Context7LiveOptions
+  readonly urlFetcher?: UrlFetcherLiveOptions
 }
 
 export const MainLive = (
   options: MainLiveOptions,
-): Layer.Layer<Ids | Groq | ResearchRepository, GroqAuthError> =>
+): Layer.Layer<
+  Ids | Groq | ResearchRepository | BraveSearch | Context7 | UrlFetcher,
+  GroqAuthError
+> =>
   Layer.mergeAll(
     IdsLive,
     GroqLive(options.groq),
     RepositoryD1Live({ D1: options.D1 }),
+    BraveLive(options.brave ?? { apiKey: undefined }),
+    Context7Live(options.context7 ?? {}),
+    UrlFetcherLive(options.urlFetcher ?? {}),
   )
 
 /**


### PR DESCRIPTION
## Summary

- Implement three new research tools enabling the agent to ground recommendations:
  - `webSearch(query, count?)` — Brave Search API integration
  - `searchLibraryDocs(library, query)` — Context7 public API for library documentation
  - `readUrl(url)` — generic URL fetching for detailed content extraction
- Add Brave Search API client with full error classification (auth, rate limit, network, API errors)
- Add Context7 client orchestrating library search + context fetch
- Add URL fetcher with timeout, size, and HTTP error handling
- Update agent loop system prompt to instruct tool use and grounding strategy
- Wire up BRAVE_API_KEY secret (Context7 uses public endpoint, no key required)
- Comprehensive test coverage: unit tests for each seam, research tool dispatch tests, and integration test for full loop

## Testing

- Research tools dispatch through catalog with correct Schema decoding and Continue outcomes
- Brave client: authentication required, 429 rate limit detection with retry-after header, API error parsing
- Context7 client: searchLibrary chains to fetchContext, returns 404 on zero results
- URL fetcher: extracts readable content, handles timeout/size/HTTP errors
- Integration test: webSearch invocation emits tool_invoked and tool_result events with correct payloads
- Local dev: requires BRAVE_API_KEY in .env for webSearch; other tools work without keys