### PR TITLE
Slice 12: Session access control, error handling with retries, and research tools

### DIFF
--- a/.claude/ralph-loop.local.md
+++ b/.claude/ralph-loop.local.md
@@ -4,7 +4,7 @@ iteration: 1
 session_id: 
 max_iterations: 0
 completion_promise: null
-started_at: "2026-05-02T20:04:49Z"
+started_at: "2026-05-03T12:35:00Z"
 ---
 
-loop through issue no 2 to 5, and implement using tdd skill
+yes implement

--- a/src/components/session-view.tsx
+++ b/src/components/session-view.tsx
@@ -21,6 +21,7 @@ import { Effect } from 'effect'
 import {
   decodeMessageEvent,
   type AgentEvent,
+  type ErrorEvent,
   type QuestionAskedEvent,
 } from '~/shared/sse/events'
 import { QuestionCard } from '~/components/question-card'
@@ -68,6 +69,7 @@ export function SessionView({ sessionId }: SessionViewProps) {
       handle('prd_section_written'),
     )
     source.addEventListener('done', handle('done'))
+    source.addEventListener('error', handle('error'))
     source.onerror = () => {
       // EventSource doesn't expose the HTTP status. A failure before any
       // event arrived is almost always the 403 from the cookie check
@@ -86,38 +88,90 @@ export function SessionView({ sessionId }: SessionViewProps) {
   }
 
   return (
-    <section className="grid gap-4 lg:grid-cols-2">
-      <div className="space-y-2">
-        <div className="text-xs text-gray-500">
-          session: <code>{sessionId}</code>
+    <div className="space-y-4">
+      <ErrorBanners events={events} />
+      <section className="grid gap-4 lg:grid-cols-2">
+        <div className="space-y-2">
+          <div className="text-xs text-gray-500">
+            session: <code>{sessionId}</code>
+          </div>
+          <ol className="space-y-2">
+            {events.map((evt) =>
+              evt.type === 'question_asked' ? (
+                <li key={evt.id}>
+                  <QuestionCard
+                    sessionId={sessionId}
+                    question={evt as QuestionAskedEvent}
+                  />
+                </li>
+              ) : (
+                <li
+                  key={evt.id}
+                  className="rounded border border-gray-200 p-2 text-sm"
+                >
+                  <div className="text-xs uppercase tracking-wide text-gray-500">
+                    {evt.type}
+                  </div>
+                  <pre className="whitespace-pre-wrap text-sm">
+                    {renderEvent(evt)}
+                  </pre>
+                </li>
+              ),
+            )}
+          </ol>
         </div>
-        <ol className="space-y-2">
-          {events.map((evt) =>
-            evt.type === 'question_asked' ? (
-              <li key={evt.id}>
-                <QuestionCard
-                  sessionId={sessionId}
-                  question={evt as QuestionAskedEvent}
-                />
-              </li>
-            ) : (
-              <li
-                key={evt.id}
-                className="rounded border border-gray-200 p-2 text-sm"
-              >
-                <div className="text-xs uppercase tracking-wide text-gray-500">
-                  {evt.type}
-                </div>
-                <pre className="whitespace-pre-wrap text-sm">
-                  {renderEvent(evt)}
-                </pre>
-              </li>
-            ),
-          )}
-        </ol>
-      </div>
-      <PrdPane sessionId={sessionId} events={events} />
-    </section>
+        <PrdPane sessionId={sessionId} events={events} />
+      </section>
+    </div>
+  )
+}
+
+/**
+ * Renders the retry / failed status above the event timeline.
+ *
+ *   - `error/failed` is **persistent**: once it appears, the session is
+ *     dead — the loop won't recover, and the user needs to know it
+ *     reached a terminal state.
+ *   - `error/retry` is **transient**: the loop is still trying. We only
+ *     show the retry banner when the *most recent* event is a retry; as
+ *     soon as a successful turn (`agent_thinking`, `tool_invoked`, …)
+ *     comes through, the banner clears.
+ *
+ * `failed` takes precedence over `retry` — once a session has failed,
+ * even past retry events shouldn't shadow that.
+ */
+function ErrorBanners({ events }: { events: ReadonlyArray<AgentEvent> }) {
+  const failed = events.find(
+    (e): e is ErrorEvent => e.type === 'error' && e.kind === 'failed',
+  )
+  const last = events[events.length - 1]
+  const retry: ErrorEvent | undefined =
+    !failed && last?.type === 'error' && last.kind === 'retry'
+      ? last
+      : undefined
+
+  if (!failed && !retry) return null
+
+  return (
+    <div className="space-y-2" role="status" aria-live="polite">
+      {failed && (
+        <div
+          role="alert"
+          className="rounded border border-red-400 bg-red-50 p-3 text-sm text-red-800"
+        >
+          <div className="font-semibold">Session failed</div>
+          <div className="mt-1 whitespace-pre-wrap">{failed.reason}</div>
+        </div>
+      )}
+      {retry && (
+        <div className="rounded border border-amber-300 bg-amber-50 p-3 text-sm text-amber-800">
+          <div className="font-semibold">
+            Retrying… (attempt {retry.attempt ?? '?'} of 3)
+          </div>
+          <div className="mt-1 whitespace-pre-wrap">{retry.reason}</div>
+        </div>
+      )}
+    </div>
   )
 }
 
@@ -204,5 +258,9 @@ function renderEvent(evt: AgentEvent): string {
       return `${evt.question}\n\n→ recommendation: ${evt.recommendation}\n→ rationale: ${evt.rationale}`
     case 'prd_section_written':
       return `[${evt.section}] ${evt.content.slice(0, 80)}…`
+    case 'error':
+      return evt.kind === 'retry'
+        ? `retrying (attempt ${evt.attempt ?? '?'}): ${evt.reason}`
+        : `failed: ${evt.reason}`
   }
 }

--- a/src/do/research.ts
+++ b/src/do/research.ts
@@ -46,6 +46,11 @@ import {
 } from '~/shared/session/state-machine'
 import { encode, type AgentEvent } from '~/shared/sse/events'
 import { MainLive } from '~/shared/runtime/main'
+import {
+  STATE_TO_DB,
+  persistStepForEvent,
+  transitionEventForLastEvent,
+} from '~/shared/research/orchestrator'
 
 /* ------------------------------------------------------------------ *
  * Request schemas
@@ -69,14 +74,6 @@ const AnswerRequest = Schema.Struct({
 
 const decodeStreamRequest = Schema.decodeUnknown(StreamRequest)
 const decodeAnswerRequest = Schema.decodeUnknown(AnswerRequest)
-
-const STATE_TO_DB: Record<SessionState, ResearchSessionStatus> = {
-  RUNNING: ResearchSessionStatus.active,
-  WAITING_FOR_USER: ResearchSessionStatus.waitingForUser,
-  COMPLETED: ResearchSessionStatus.completed,
-  FAILED: ResearchSessionStatus.failed,
-  ABANDONED: ResearchSessionStatus.abandoned,
-}
 
 /* ------------------------------------------------------------------ *
  * Durable Object
@@ -170,14 +167,16 @@ export class ResearchDO extends DurableObject {
     const sessionId = this.sessionId
 
     const program = Effect.gen(this, function* (this: ResearchDO) {
-      const repo = yield* ResearchRepository
       const catalog = makeCatalog(builtinTools)
-      const lastEventTypeRef = yield* Ref.make<AgentEvent['type'] | undefined>(
-        undefined,
-      )
+      const lastEventRef = yield* Ref.make<AgentEvent | undefined>(undefined)
 
+      // Persist every live event through the orchestrator helper so the
+      // mapping AgentEvent → research_steps row (including the new
+      // status/errorMessage encoding for `error/*` events introduced in
+      // Slice 12) lives in one place. Replay events are not handed to
+      // this function — they're already in the durable log.
       const persistStep = (event: AgentEvent) =>
-        repo.appendStep({ sessionId, event })
+        persistStepForEvent(sessionId, event)
 
       const writeFrame = (event: AgentEvent) =>
         Effect.promise(() => writer.write(encoder.encode(encode(event))))
@@ -196,7 +195,7 @@ export class ResearchDO extends DurableObject {
         Stream.tap((event) =>
           Effect.gen(this, function* (this: ResearchDO) {
             yield* writeFrame(event)
-            yield* Ref.set(lastEventTypeRef, event.type)
+            yield* Ref.set(lastEventRef, event)
             if (event.id + 1 > this.nextStepNumber) {
               this.nextStepNumber = event.id + 1
             }
@@ -205,23 +204,33 @@ export class ResearchDO extends DurableObject {
         Stream.runDrain,
       )
 
-      const lastType = yield* Ref.get(lastEventTypeRef)
-      const transitionEvent: SessionEvent =
-        lastType === 'question_asked' ? 'askQuestion' : 'finalize'
-      yield* this.transitionTo(transitionEvent)
+      const lastEvent = yield* Ref.get(lastEventRef)
+      const transitionEvent: SessionEvent | undefined =
+        lastEvent !== undefined
+          ? transitionEventForLastEvent(lastEvent)
+          : undefined
+      if (transitionEvent !== undefined) {
+        yield* this.transitionTo(transitionEvent)
+      }
     })
 
     void Effect.runPromise(
       program.pipe(
         Effect.catchAllCause((cause) =>
           Effect.gen(this, function* (this: ResearchDO) {
-            const summary = `error: ${Cause.pretty(cause)}`
+            // Non-retryable failure escaped the loop (auth error, schema
+            // mismatch, repository unknown). Surface it as an `error/failed`
+            // event so the frontend renders the persistent banner, persist
+            // a corresponding step row, and transition to FAILED.
+            const reason = Cause.pretty(cause)
             const event: AgentEvent = {
               id: this.nextStepNumber,
-              type: 'done',
-              finalText: summary,
+              type: 'error',
+              kind: 'failed',
+              reason,
             }
             this.nextStepNumber++
+            yield* persistStepForEvent(sessionId, event).pipe(Effect.ignore)
             yield* Effect.promise(() =>
               writer.write(encoder.encode(encode(event))).catch(() => {}),
             )

--- a/src/shared/agent/loop.test.ts
+++ b/src/shared/agent/loop.test.ts
@@ -18,8 +18,16 @@ import { describe, it, expect } from '@effect/vitest'
 import { Chunk, Effect, Layer, Stream } from 'effect'
 import type OpenAI from 'openai'
 import { IdsTest } from '~/shared/domain/ids'
-import { GroqStub } from '~/shared/infra/groq/client'
+import { BraveStub } from '~/shared/infra/brave/client'
+import { Context7Stub } from '~/shared/infra/context7/client'
+import { UrlFetcherStub } from '~/shared/infra/url-fetcher/client'
+import { GroqStub, type GroqStubTurn } from '~/shared/infra/groq/client'
 import { RepositoryInMemoryLive } from '~/shared/infra/drizzle/repository'
+import {
+  GroqApiError,
+  GroqAuthError,
+  GroqRateLimitError,
+} from '~/shared/domain/errors'
 import { runLoop } from './loop'
 import { makeCatalog, SessionContext } from './tools/catalog'
 import { builtinTools } from './tools/builtin'
@@ -64,10 +72,16 @@ const completion = (
 
 const SessionFixed = Layer.succeed(SessionContext, { sessionId: 's' })
 
+// Empty research-tool stubs — these tests don't drive the search path, so
+// nothing needs canned responses; we just have to satisfy the requirements
+// the catalog declares (Slice 11 added them).
 const TestEnv = Layer.mergeAll(
   RepositoryInMemoryLive,
   IdsTest,
   SessionFixed,
+  BraveStub.layer([]),
+  Context7Stub.layer({}),
+  UrlFetcherStub.layer([]),
 )
 
 const catalog = makeCatalog(builtinTools)
@@ -200,5 +214,201 @@ describe('agent loop', () => {
       if (last.type !== 'done') throw new Error('expected done')
       expect(last.finalText).toBe('all set')
     }),
+  )
+
+  it.effect(
+    'repairs malformed tool call: unknown tool name → next turn finalizes',
+    () =>
+      Effect.gen(function* () {
+        // Turn 1: LLM emits a call to a tool that doesn't exist. Without
+        // repair, the dispatcher fails with ToolUnknownError and the stream
+        // dies. With repair, the loop appends a synthetic message to the
+        // history and asks Groq again.
+        // Turn 2: LLM corrects itself with a valid finalize.
+        const turns: ReadonlyArray<OpenAI.ChatCompletion> = [
+          completion('c1', {
+            toolCalls: [
+              { id: 'tc1', name: 'nonExistentTool', args: { foo: 'bar' } },
+            ],
+          }),
+          completion('c2', {
+            toolCalls: [
+              { id: 'tc2', name: 'finalize', args: { summary: 'recovered' } },
+            ],
+          }),
+        ]
+
+        const events = yield* Stream.runCollect(
+          runLoop({ prompt: 'go' }, catalog),
+        ).pipe(Effect.provide(Layer.merge(TestEnv, GroqStub.layer(turns))))
+
+        const arr = Chunk.toReadonlyArray(events) as ReadonlyArray<AgentEvent>
+        const last = arr[arr.length - 1]!
+        if (last.type !== 'done') throw new Error(`expected done, got ${last.type}`)
+        expect(last.finalText).toBe('recovered')
+      }),
+  )
+
+  // `it.live` — these tests exercise the real backoff scheduler. Under the
+  // default `it.effect` TestClock, `Effect.sleep` would never tick.
+  it.live('retries Groq 429 with backoff and emits a retry event', () =>
+    Effect.gen(function* () {
+      // 1st call rate-limits; 2nd succeeds with finalize.
+      const turns: ReadonlyArray<GroqStubTurn> = [
+        { _err: new GroqRateLimitError({ retryAfterSeconds: 0 }) },
+        completion('c2', {
+          toolCalls: [
+            { id: 'tc1', name: 'finalize', args: { summary: 'recovered' } },
+          ],
+        }),
+      ]
+
+      const events = yield* Stream.runCollect(
+        runLoop(
+          { prompt: 'go', groqRetryBaseDelayMs: 1 },
+          catalog,
+        ),
+      ).pipe(Effect.provide(Layer.merge(TestEnv, GroqStub.layer(turns))))
+
+      const arr = Chunk.toReadonlyArray(events) as ReadonlyArray<AgentEvent>
+      const retry = arr.find((e) => e.type === 'error' && e.kind === 'retry')
+      if (!retry || retry.type !== 'error')
+        throw new Error('expected an error/retry event')
+      expect(retry.attempt).toBe(1)
+      expect(retry.reason).toMatch(/rate.?limit|429/i)
+
+      const last = arr[arr.length - 1]!
+      if (last.type !== 'done')
+        throw new Error(`expected done, got ${last.type}`)
+      expect(last.finalText).toBe('recovered')
+    }),
+  )
+
+  it.live('retries Groq 5xx with backoff and emits a retry event', () =>
+    Effect.gen(function* () {
+      const turns: ReadonlyArray<GroqStubTurn> = [
+        { _err: new GroqApiError({ status: 503, body: 'service unavailable' }) },
+        completion('c2', {
+          toolCalls: [
+            { id: 'tc1', name: 'finalize', args: { summary: 'recovered 5xx' } },
+          ],
+        }),
+      ]
+
+      const events = yield* Stream.runCollect(
+        runLoop(
+          { prompt: 'go', groqRetryBaseDelayMs: 1 },
+          catalog,
+        ),
+      ).pipe(Effect.provide(Layer.merge(TestEnv, GroqStub.layer(turns))))
+
+      const arr = Chunk.toReadonlyArray(events) as ReadonlyArray<AgentEvent>
+      const retry = arr.find((e) => e.type === 'error' && e.kind === 'retry')
+      if (!retry || retry.type !== 'error')
+        throw new Error('expected an error/retry event')
+      expect(retry.attempt).toBe(1)
+      expect(retry.reason).toMatch(/503|service unavailable|5xx/i)
+
+      const last = arr[arr.length - 1]!
+      if (last.type !== 'done')
+        throw new Error(`expected done, got ${last.type}`)
+      expect(last.finalText).toBe('recovered 5xx')
+    }),
+  )
+
+  it.live(
+    'emits 3 retry events + error/failed and halts when Groq retries exhaust',
+    () =>
+      Effect.gen(function* () {
+        const turns: ReadonlyArray<GroqStubTurn> = [
+          { _err: new GroqRateLimitError({}) },
+          { _err: new GroqRateLimitError({}) },
+          { _err: new GroqRateLimitError({}) },
+          { _err: new GroqRateLimitError({}) },
+        ]
+
+        const events = yield* Stream.runCollect(
+          runLoop(
+            { prompt: 'go', groqRetryBaseDelayMs: 1 },
+            catalog,
+          ),
+        ).pipe(Effect.provide(Layer.merge(TestEnv, GroqStub.layer(turns))))
+
+        const arr = Chunk.toReadonlyArray(events) as ReadonlyArray<AgentEvent>
+        const retries = arr.filter(
+          (e) => e.type === 'error' && e.kind === 'retry',
+        )
+        expect(retries).toHaveLength(3)
+        expect((retries[0] as { attempt?: number }).attempt).toBe(1)
+        expect((retries[1] as { attempt?: number }).attempt).toBe(2)
+        expect((retries[2] as { attempt?: number }).attempt).toBe(3)
+
+        const last = arr[arr.length - 1]!
+        if (last.type !== 'error')
+          throw new Error(`expected error, got ${last.type}`)
+        expect(last.kind).toBe('failed')
+        expect(last.reason).toMatch(/rate.?limit|429/i)
+      }),
+  )
+
+  it.effect('non-retryable Groq error (auth) propagates as a stream failure', () =>
+    Effect.gen(function* () {
+      const turns: ReadonlyArray<GroqStubTurn> = [
+        { _err: new GroqAuthError({ reason: 'bad key' }) },
+      ]
+
+      const exit = yield* Effect.exit(
+        Stream.runCollect(
+          runLoop(
+            { prompt: 'go', groqRetryBaseDelayMs: 1 },
+            catalog,
+          ),
+        ).pipe(Effect.provide(Layer.merge(TestEnv, GroqStub.layer(turns)))),
+      )
+      // The loop should NOT silently retry an auth error — it surfaces as a
+      // typed failure so the DO can render a 502.
+      expect(exit._tag).toBe('Failure')
+    }),
+  )
+
+  it.effect(
+    'emits error/failed and halts after 3 consecutive malformed tool calls',
+    () =>
+      Effect.gen(function* () {
+        // 3 consecutive turns of malformed calls. The 3rd should trigger
+        // the terminal error event; the 4th canned response should never
+        // be consumed.
+        const bad = (i: number) =>
+          completion(`c${i}`, {
+            toolCalls: [
+              { id: `tc${i}`, name: 'nonExistentTool', args: { i } },
+            ],
+          })
+        const turns: ReadonlyArray<OpenAI.ChatCompletion> = [
+          bad(1),
+          bad(2),
+          bad(3),
+          // canary: if the loop kept asking, this is what it would see.
+          completion('c4', {
+            toolCalls: [
+              { id: 'tc4', name: 'finalize', args: { summary: 'should not reach' } },
+            ],
+          }),
+        ]
+
+        const events = yield* Stream.runCollect(
+          runLoop({ prompt: 'go' }, catalog),
+        ).pipe(Effect.provide(Layer.merge(TestEnv, GroqStub.layer(turns))))
+
+        const arr = Chunk.toReadonlyArray(events) as ReadonlyArray<AgentEvent>
+        const last = arr[arr.length - 1]!
+        if (last.type !== 'error')
+          throw new Error(`expected error, got ${last.type}`)
+        expect(last.kind).toBe('failed')
+        expect(last.reason).toMatch(/unknown tool/i)
+
+        // No `done` event was emitted.
+        expect(arr.find((e) => e.type === 'done')).toBeUndefined()
+      }),
   )
 })

--- a/src/shared/agent/loop.ts
+++ b/src/shared/agent/loop.ts
@@ -25,15 +25,18 @@
  * Persistence (research_steps), state-machine transitions, and SSE
  * write-outs live one layer up — the loop is pure stream-of-events.
  */
-import { Chunk, Effect, Option, Stream } from 'effect'
+import { Chunk, Effect, Either, Option, Stream } from 'effect'
 import type OpenAI from 'openai'
 import {
+  type GroqError,
   GroqEmptyCompletionError,
   type LoopError,
+  type ToolError,
 } from '~/shared/domain/errors'
-import { Groq } from '~/shared/infra/groq/client'
+import { Groq, type GroqChatCompletionParams } from '~/shared/infra/groq/client'
 import type { AgentEvent } from '~/shared/sse/events'
 import type { ToolCatalog } from './tools/catalog'
+import type { ToolOutcome } from '~/shared/infra/ai/tool'
 
 /* ------------------------------------------------------------------ *
  * Public API
@@ -48,11 +51,30 @@ export interface RunLoopInput {
   readonly hardCap?: number
   /** Step number the first emitted event should carry. Default 1. */
   readonly startStepNumber?: number
+  /**
+   * Base delay (millis) for Groq retry backoff. With 3 retries, the loop
+   * sleeps `base × 2^n` between attempts: 1s, 2s, 4s by default. Tests
+   * pass `1` so the suite stays fast.
+   */
+  readonly groqRetryBaseDelayMs?: number
 }
 
 const DEFAULT_MODEL = 'llama-3.1-8b-instant'
 const DEFAULT_SOFT_CAP = 50
 const DEFAULT_HARD_CAP = 100
+/**
+ * After this many consecutive turns with malformed tool calls, the loop
+ * gives up and emits a terminal `error/failed` event. The DO converts that
+ * into a `FAILED` state transition.
+ */
+const MAX_REPAIR_ATTEMPTS = 3
+/**
+ * How many transient-Groq retries the loop will attempt before giving up.
+ * Three retries means up to four total Groq calls per turn, with backoffs
+ * of `base × 1, 2, 4` milliseconds between them.
+ */
+const MAX_GROQ_RETRIES = 3
+const DEFAULT_GROQ_RETRY_BASE_MS = 1000
 
 const SYSTEM = (softCap: number): string =>
   `You are a Research agent grilling the user about a feature so you can produce a PRD.\n` +
@@ -72,6 +94,8 @@ export const runLoop = <R, E>(
   const model = input.model ?? DEFAULT_MODEL
   const softCap = input.softCap ?? DEFAULT_SOFT_CAP
   const hardCap = input.hardCap ?? DEFAULT_HARD_CAP
+  const groqRetryBaseDelayMs =
+    input.groqRetryBaseDelayMs ?? DEFAULT_GROQ_RETRY_BASE_MS
 
   const initial: LoopState = {
     history: [
@@ -80,10 +104,11 @@ export const runLoop = <R, E>(
     ],
     stepNumber: input.startStepNumber ?? 1,
     turns: 0,
+    repairAttempts: 0,
   }
 
   return Stream.paginateChunkEffect(initial, (state) =>
-    step(state, model, hardCap, catalog),
+    step(state, model, hardCap, catalog, groqRetryBaseDelayMs),
   )
 }
 
@@ -95,13 +120,69 @@ interface LoopState {
   readonly history: ReadonlyArray<OpenAI.ChatCompletionMessageParam>
   readonly stepNumber: number
   readonly turns: number
+  /**
+   * How many turns in a row the LLM emitted at least one malformed tool
+   * call (unknown tool, invalid JSON, schema mismatch). Resets to 0 on a
+   * clean turn.
+   */
+  readonly repairAttempts: number
 }
+
+/* ------------------------------------------------------------------ *
+ * Tool-call repair
+ *
+ * When `catalog.dispatch` fails with a *validation* error (unknown tool,
+ * bad JSON, schema mismatch), we don't kill the loop — we feed a synthetic
+ * tool-message back to the LLM saying "previous tool call was invalid:
+ * <reason>; try again" and ask it to retry. `ToolExecutionError` is *not*
+ * repairable: that's a real failure inside a tool's execute, surface it.
+ * ------------------------------------------------------------------ */
+
+type DispatchOutcome =
+  | { readonly kind: 'ok'; readonly outcome: ToolOutcome }
+  | { readonly kind: 'repair'; readonly reason: string }
+
+type RepairableToolError = Extract<
+  ToolError,
+  { _tag: 'ToolUnknownError' | 'ToolInputJsonError' | 'ToolInputParseError' }
+>
+
+const isRepairable = (err: unknown): err is RepairableToolError => {
+  if (typeof err !== 'object' || err === null || !('_tag' in err)) return false
+  const tag = (err as { _tag: unknown })._tag
+  return (
+    tag === 'ToolUnknownError' ||
+    tag === 'ToolInputJsonError' ||
+    tag === 'ToolInputParseError'
+  )
+}
+
+const repairReason = (err: RepairableToolError): string => {
+  switch (err._tag) {
+    case 'ToolUnknownError':
+      return `unknown tool '${err.toolName}'`
+    case 'ToolInputJsonError':
+      return `invalid JSON arguments for tool '${err.toolName}'`
+    case 'ToolInputParseError':
+      return `schema validation failed for tool '${err.toolName}'`
+  }
+}
+
+const repairToolMessage = (
+  toolCallId: string,
+  reason: string,
+): OpenAI.ChatCompletionMessageParam => ({
+  role: 'tool',
+  tool_call_id: toolCallId,
+  content: `previous tool call was invalid: ${reason}; try again`,
+})
 
 const step = <R, E>(
   state: LoopState,
   model: string,
   hardCap: number,
   catalog: ToolCatalog<R, E>,
+  groqRetryBaseDelayMs: number,
 ): Effect.Effect<
   readonly [Chunk.Chunk<AgentEvent>, Option.Option<LoopState>],
   LoopError | E,
@@ -119,11 +200,23 @@ const step = <R, E>(
     }
 
     const groq = yield* Groq
-    const completion = yield* groq.chatCompletion({
-      model,
-      messages: state.history,
-      tools: catalog.openAITools,
-    })
+    const groqResult = yield* callGroqWithRetries(
+      groq,
+      {
+        model,
+        messages: state.history,
+        tools: catalog.openAITools,
+      },
+      state.stepNumber,
+      groqRetryBaseDelayMs,
+    )
+    if (groqResult.kind === 'failed') {
+      return [
+        Chunk.fromIterable(groqResult.events),
+        Option.none<LoopState>(),
+      ] as const
+    }
+    const completion = groqResult.completion
 
     const message = completion.choices[0]?.message
     if (!message) {
@@ -131,8 +224,8 @@ const step = <R, E>(
     }
 
     const text = message.content ?? ''
-    const events: Array<AgentEvent> = []
-    let stepNumber = state.stepNumber
+    const events: Array<AgentEvent> = [...groqResult.events]
+    let stepNumber = groqResult.nextStepNumber
 
     events.push({ id: stepNumber++, type: 'agent_thinking', text })
 
@@ -150,6 +243,8 @@ const step = <R, E>(
       return [Chunk.fromIterable(events), Option.none<LoopState>()] as const
     }
 
+    let hadRepair = false
+
     for (const call of message.tool_calls) {
       if (call.type !== 'function') continue
       const args = safeParseJson(call.function.arguments)
@@ -161,10 +256,35 @@ const step = <R, E>(
         args,
       })
 
-      const outcome = yield* catalog.dispatch({
-        name: call.function.name,
-        rawArguments: call.function.arguments,
-      })
+      const dispatched: DispatchOutcome = yield* catalog
+        .dispatch({
+          name: call.function.name,
+          rawArguments: call.function.arguments,
+        })
+        .pipe(
+          Effect.map(
+            (outcome): DispatchOutcome => ({ kind: 'ok', outcome }),
+          ),
+          Effect.catchAll((err) =>
+            isRepairable(err)
+              ? Effect.succeed<DispatchOutcome>({
+                  kind: 'repair',
+                  reason: repairReason(err),
+                })
+              : Effect.fail(err),
+          ),
+        )
+
+      if (dispatched.kind === 'repair') {
+        // Don't emit tool_result; the LLM will try again next turn. Append
+        // a synthetic tool-message so the OpenAI API contract (every
+        // tool_call needs a tool response) holds.
+        newHistory.push(repairToolMessage(call.id, dispatched.reason))
+        hadRepair = true
+        continue
+      }
+
+      const outcome = dispatched.outcome
 
       if (outcome._tag === 'Pause') {
         events.push({
@@ -220,12 +340,41 @@ const step = <R, E>(
       })
     }
 
+    const nextRepairAttempts = hadRepair ? state.repairAttempts + 1 : 0
+
+    if (nextRepairAttempts >= MAX_REPAIR_ATTEMPTS) {
+      // Find the most recent repair reason from the synthetic tool messages
+      // we appended this turn — `tool_call_id` + content carry the why.
+      const lastSynthetic = [...newHistory]
+        .reverse()
+        .find(
+          (m) =>
+            m.role === 'tool' &&
+            typeof m.content === 'string' &&
+            m.content.startsWith('previous tool call was invalid: '),
+        ) as OpenAI.ChatCompletionToolMessageParam | undefined
+      const reason =
+        typeof lastSynthetic?.content === 'string'
+          ? lastSynthetic.content
+              .replace(/^previous tool call was invalid: /, '')
+              .replace(/; try again$/, '')
+          : 'malformed tool call'
+      events.push({
+        id: stepNumber++,
+        type: 'error',
+        kind: 'failed',
+        reason: `tool-call repair attempts exhausted: ${reason}`,
+      })
+      return [Chunk.fromIterable(events), Option.none<LoopState>()] as const
+    }
+
     return [
       Chunk.fromIterable(events),
       Option.some<LoopState>({
         history: newHistory,
         stepNumber,
         turns: state.turns + 1,
+        repairAttempts: nextRepairAttempts,
       }),
     ] as const
   })
@@ -237,3 +386,115 @@ const safeParseJson = (raw: string): unknown => {
     return {}
   }
 }
+
+/* ------------------------------------------------------------------ *
+ * Groq retry / failure handling
+ *
+ * Wraps a single `groq.chatCompletion` call with backoff-and-retry so
+ * the loop can emit `error/retry` events between attempts and an
+ * `error/failed` event when the retries exhaust. Non-retryable Groq
+ * errors (auth, schema-empty, etc.) propagate as stream failures so the
+ * DO can render a typed error response.
+ * ------------------------------------------------------------------ */
+
+const isGroqRetryable = (e: GroqError): boolean => {
+  if (e._tag === 'GroqRateLimitError') return true
+  if (e._tag === 'GroqNetworkError') return true
+  if (e._tag === 'GroqApiError') {
+    return e.status >= 500 && e.status < 600
+  }
+  return false
+}
+
+const groqErrorReason = (e: GroqError): string => {
+  switch (e._tag) {
+    case 'GroqRateLimitError':
+      return e.retryAfterSeconds !== undefined
+        ? `Groq rate-limited (429), retry-after ${e.retryAfterSeconds}s`
+        : 'Groq rate-limited (429)'
+    case 'GroqNetworkError':
+      return 'Groq network error'
+    case 'GroqApiError':
+      return `Groq API error (${e.status}): ${e.body}`
+    case 'GroqAuthError':
+      return `Groq auth error: ${e.reason}`
+    case 'GroqParseError':
+      return 'Groq response parse error'
+    case 'GroqEmptyCompletionError':
+      return 'Groq returned an empty completion'
+  }
+}
+
+interface GroqCallOk {
+  readonly kind: 'ok'
+  readonly completion: OpenAI.ChatCompletion
+  readonly events: ReadonlyArray<AgentEvent>
+  readonly nextStepNumber: number
+}
+
+interface GroqCallFailed {
+  readonly kind: 'failed'
+  readonly events: ReadonlyArray<AgentEvent>
+  readonly nextStepNumber: number
+}
+
+type GroqCallResult = GroqCallOk | GroqCallFailed
+
+const callGroqWithRetries = (
+  groq: Effect.Effect.Success<typeof Groq>,
+  params: GroqChatCompletionParams,
+  startStepNumber: number,
+  baseDelayMs: number,
+): Effect.Effect<GroqCallResult, GroqError> =>
+  Effect.gen(function* () {
+    const events: Array<AgentEvent> = []
+    let stepNumber = startStepNumber
+
+    for (let attempt = 1; attempt <= MAX_GROQ_RETRIES + 1; attempt++) {
+      const result = yield* groq.chatCompletion(params).pipe(Effect.either)
+      if (Either.isRight(result)) {
+        return {
+          kind: 'ok',
+          completion: result.right,
+          events,
+          nextStepNumber: stepNumber,
+        } as GroqCallResult
+      }
+      const err = result.left
+      if (!isGroqRetryable(err)) {
+        return yield* Effect.fail(err)
+      }
+      // Last attempt failed AND was retryable → give up.
+      if (attempt > MAX_GROQ_RETRIES) {
+        events.push({
+          id: stepNumber++,
+          type: 'error',
+          kind: 'failed',
+          reason: `Groq retries exhausted: ${groqErrorReason(err)}`,
+        })
+        return {
+          kind: 'failed',
+          events,
+          nextStepNumber: stepNumber,
+        } as GroqCallResult
+      }
+      // More attempts left — emit retry event, sleep, and try again.
+      events.push({
+        id: stepNumber++,
+        type: 'error',
+        kind: 'retry',
+        attempt,
+        reason: groqErrorReason(err),
+      })
+      yield* Effect.sleep(`${baseDelayMs * 2 ** (attempt - 1)} millis`)
+    }
+
+    // Unreachable — the loop above always returns within MAX_GROQ_RETRIES+1
+    // iterations. Returning a failed result is just to satisfy the type
+    // checker.
+    return {
+      kind: 'failed',
+      events,
+      nextStepNumber: stepNumber,
+    } as GroqCallResult
+  })

--- a/src/shared/infra/drizzle/repository.ts
+++ b/src/shared/infra/drizzle/repository.ts
@@ -36,6 +36,7 @@ import {
   PrdSection,
   ResearchQuestion,
   ResearchSessionRow,
+  ResearchStepRow,
   type SessionStatus,
 } from './schemas'
 import { AgentEvent } from '~/shared/sse/events'
@@ -101,6 +102,9 @@ export class ResearchRepository extends Context.Tag('ResearchRepository')<
       sessionId: string,
       lastEventId: number,
     ) => Effect.Effect<ReadonlyArray<AgentEvent>, RepositoryError>
+    readonly listStepsBySession: (
+      sessionId: string,
+    ) => Effect.Effect<ReadonlyArray<ResearchStepRow>, RepositoryError>
     readonly recordQuestion: (
       input: NewQuestion,
     ) => Effect.Effect<void, RepositoryError>
@@ -166,6 +170,7 @@ interface StepRowFields {
   readonly llmResponse: string | null
   readonly toolRequest: string | null
   readonly toolResponse: string | null
+  readonly errorMessage: string | null
   readonly status: ResearchStepStatus
   readonly event: string
 }
@@ -173,6 +178,11 @@ interface StepRowFields {
 const projectStep = (input: NewStep): StepRowFields => {
   const { event } = input
   const encoded = JSON.stringify(encodeAgentEvent(event))
+  // For `error/*` events the loop owns the failure semantics: `retry`
+  // events stay status:success (mid-recovery) but carry the reason in
+  // `errorMessage`; `failed` is the terminal step (status:failure).
+  const isFailedError = event.type === 'error' && event.kind === 'failed'
+  const errorMessage = event.type === 'error' ? event.reason : null
   return {
     sessionId: input.sessionId,
     stepNumber: event.id,
@@ -187,7 +197,10 @@ const projectStep = (input: NewStep): StepRowFields => {
         : event.type === 'done'
           ? event.finalText
           : null,
-    status: ResearchStepStatus.success,
+    errorMessage,
+    status: isFailedError
+      ? ResearchStepStatus.failure
+      : ResearchStepStatus.success,
     event: encoded,
   }
 }
@@ -218,6 +231,7 @@ const makeD1 = (env: { D1: D1Database }) => {
   const decodeSession = decodeRow(ResearchSessionRow, 'ResearchSession')
   const decodeQuestion = decodeRow(ResearchQuestion, 'ResearchQuestion')
   const decodePrdSection = decodeRow(PrdSection, 'PrdSection')
+  const decodeStep = decodeRow(ResearchStepRow, 'ResearchStep')
 
   return ResearchRepository.of({
     createSession: (input) =>
@@ -277,6 +291,18 @@ const makeD1 = (env: { D1: D1Database }) => {
             .orderBy(asc(researchSteps.stepNumber)),
         )
         return yield* Effect.forEach(rows, (r) => parseEventColumn(r.event))
+      }),
+
+    listStepsBySession: (sessionId) =>
+      Effect.gen(function* () {
+        const rows = yield* tryDb(() =>
+          db
+            .select()
+            .from(researchSteps)
+            .where(eq(researchSteps.sessionId, sessionId))
+            .orderBy(asc(researchSteps.id)),
+        )
+        return yield* Effect.forEach(rows, (r) => decodeStep(r))
       }),
 
     recordQuestion: (input) =>
@@ -378,6 +404,21 @@ interface RawQuestionRow {
   answeredAt: Date | null
 }
 
+interface RawStepRow {
+  id: number
+  sessionId: string
+  stepNumber: number
+  toolName: string | null
+  llmPrompt: string | null
+  llmResponse: string | null
+  toolRequest: string | null
+  toolResponse: string | null
+  errorMessage: string | null
+  status: ResearchStepStatus
+  event: string
+  createdAt: Date
+}
+
 interface RawPrdSectionRow {
   id: number
   sessionId: string
@@ -393,13 +434,15 @@ export const RepositoryInMemoryLive: Layer.Layer<ResearchRepository> =
       const sessions = yield* Ref.make(
         new Map<string, ResearchSessionRow>(),
       )
-      const steps = yield* Ref.make<Array<StepRowFields>>([])
+      const stepSeq = yield* Ref.make(0)
+      const steps = yield* Ref.make<Array<RawStepRow>>([])
       const questions = yield* Ref.make(new Map<string, RawQuestionRow>())
       const prdSeq = yield* Ref.make(0)
       const prdRows = yield* Ref.make<Array<RawPrdSectionRow>>([])
 
       const decodeQuestion = decodeRow(ResearchQuestion, 'ResearchQuestion')
       const decodePrdSection = decodeRow(PrdSection, 'PrdSection')
+      const decodeStep = decodeRow(ResearchStepRow, 'ResearchStep')
 
       return ResearchRepository.of({
         createSession: (input) =>
@@ -445,7 +488,27 @@ export const RepositoryInMemoryLive: Layer.Layer<ResearchRepository> =
           }),
 
         appendStep: (input) =>
-          Ref.update(steps, (arr) => [...arr, projectStep(input)]),
+          Effect.gen(function* () {
+            const id = yield* Ref.modify(stepSeq, (n) => [n + 1, n + 1])
+            const projected = projectStep(input)
+            yield* Ref.update(steps, (arr) => [
+              ...arr,
+              {
+                id,
+                sessionId: projected.sessionId,
+                stepNumber: projected.stepNumber,
+                toolName: projected.toolName,
+                llmPrompt: null,
+                llmResponse: projected.llmResponse,
+                toolRequest: projected.toolRequest,
+                toolResponse: projected.toolResponse,
+                errorMessage: projected.errorMessage,
+                status: projected.status,
+                event: projected.event,
+                createdAt: new Date(),
+              },
+            ])
+          }),
 
         getStepsAfter: (sessionId, lastEventId) =>
           Effect.gen(function* () {
@@ -458,6 +521,15 @@ export const RepositoryInMemoryLive: Layer.Layer<ResearchRepository> =
             return yield* Effect.forEach(filtered, (r) =>
               parseEventColumn(r.event),
             )
+          }),
+
+        listStepsBySession: (sessionId) =>
+          Effect.gen(function* () {
+            const arr = yield* Ref.get(steps)
+            const filtered = arr
+              .filter((r) => r.sessionId === sessionId)
+              .sort((a, b) => a.id - b.id)
+            return yield* Effect.forEach(filtered, (r) => decodeStep(r))
           }),
 
         recordQuestion: (input) =>

--- a/src/shared/infra/groq/client.ts
+++ b/src/shared/infra/groq/client.ts
@@ -1,9 +1,10 @@
 /**
  * `Groq` — Effect service for the LLM seam. The Live layer pins:
  *   - 30s per-call timeout (`GroqNetworkError` on timeout)
- *   - up to 2 retries on transient failures (network / rate-limit), with
- *     exponential backoff (500ms × 2^n)
- *   - no SDK-level retries (we own retry policy)
+ *   - **no client-level retries** — the agent loop owns retry policy
+ *     (1s, 2s, 4s with `error/retry` SSE events between attempts) so
+ *     retrying down here would silently double the work and starve the
+ *     SSE stream of progress signals.
  *
  * Error classification inspects `OpenAI.APIError` (the SDK's exception
  * type) and routes to a tagged variant. Anything else becomes
@@ -14,7 +15,7 @@
  * the old codebase used.
  */
 import OpenAI from 'openai'
-import { Context, Effect, Layer, Ref, Schedule } from 'effect'
+import { Context, Effect, Layer, Ref } from 'effect'
 import {
   type GroqError,
   GroqApiError,
@@ -64,15 +65,11 @@ const classifyError = (cause: unknown): GroqError => {
   return new GroqNetworkError({ cause })
 }
 
-const isRetryable = (e: GroqError): boolean =>
-  e._tag === 'GroqNetworkError' || e._tag === 'GroqRateLimitError'
-
 export interface GroqLiveOptions {
   readonly apiKey: string | undefined
   readonly baseURL?: string
   readonly fetch?: typeof fetch
   readonly timeoutMillis?: number
-  readonly maxRetries?: number
 }
 
 /**
@@ -98,7 +95,6 @@ export const GroqLive = (
         maxRetries: 0,
       })
       const timeoutMs = options.timeoutMillis ?? 30_000
-      const retries = options.maxRetries ?? 2
 
       return Groq.of({
         chatCompletion: (params) =>
@@ -120,11 +116,6 @@ export const GroqLive = (
               onTimeout: (): GroqError =>
                 new GroqNetworkError({ cause: 'timeout' }),
             }),
-            Effect.retry({
-              schedule: Schedule.exponential('500 millis', 2.0),
-              times: retries,
-              while: isRetryable,
-            }),
           ),
       })
     }),
@@ -134,10 +125,23 @@ export const GroqLive = (
  * Test adapter: returns canned `ChatCompletion`s in order. After the list
  * is exhausted, further calls fail with `GroqApiError`. Provide via
  * `Layer.provide(GroqStub.layer([...]))` in `it.effect`.
+ *
+ * Each turn is either a successful `ChatCompletion` or a canned failure
+ * `{ _err }` that the stub raises — useful for driving the loop's retry
+ * and repair paths without spinning up real network failure modes.
  */
+export type GroqStubTurn =
+  | OpenAI.ChatCompletion
+  | { readonly _err: GroqError }
+
+const isErrorTurn = (
+  t: GroqStubTurn,
+): t is { readonly _err: GroqError } =>
+  typeof t === 'object' && t !== null && '_err' in t
+
 export const GroqStub = {
   layer: (
-    turns: ReadonlyArray<OpenAI.ChatCompletion>,
+    turns: ReadonlyArray<GroqStubTurn>,
   ): Layer.Layer<Groq> =>
     Layer.scoped(
       Groq,
@@ -153,6 +157,9 @@ export const GroqStub = {
                   status: 0,
                   body: `GroqStub: no canned response for turn ${i + 1}`,
                 })
+              }
+              if (isErrorTurn(turn)) {
+                return yield* Effect.fail(turn._err)
               }
               return turn
             }),

--- a/src/shared/research/orchestrator.test.ts
+++ b/src/shared/research/orchestrator.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Slice 12 — failure persistence tests.
+ *
+ * Drives the agent loop through a pipeline that mirrors what the Durable
+ * Object does in production:
+ *
+ *   1. Run the loop, threading each emitted `AgentEvent` through
+ *      `persistStepForEvent` (writes the step row).
+ *   2. After the stream drains, look at the *last* event and call
+ *      `transitionEventForLastEvent` to derive the FSM event the host
+ *      should fire.
+ *   3. Apply that transition to a `Ref<SessionState>` and persist the new
+ *      session status through the same in-memory repo.
+ *
+ * The DO has the same exact two-step pipeline; testing it here lets us
+ * assert on persisted side-effects without standing up a real DO.
+ */
+import { describe, it, expect } from '@effect/vitest'
+import { Chunk, Clock, Effect, Layer, Ref, Stream } from 'effect'
+import type OpenAI from 'openai'
+import { IdsTest } from '~/shared/domain/ids'
+import { GroqRateLimitError } from '~/shared/domain/errors'
+import { BraveStub } from '~/shared/infra/brave/client'
+import { Context7Stub } from '~/shared/infra/context7/client'
+import { UrlFetcherStub } from '~/shared/infra/url-fetcher/client'
+import { GroqStub, type GroqStubTurn } from '~/shared/infra/groq/client'
+import {
+  RepositoryInMemoryLive,
+  ResearchRepository,
+} from '~/shared/infra/drizzle/repository'
+import {
+  ResearchSessionStatus,
+  ResearchStepStatus,
+} from '~/shared/infra/drizzle/schema'
+import { runLoop } from '~/shared/agent/loop'
+import { makeCatalog, SessionContext } from '~/shared/agent/tools/catalog'
+import { builtinTools } from '~/shared/agent/tools/builtin'
+import {
+  type SessionEvent,
+  type SessionState,
+  transition,
+} from '~/shared/session/state-machine'
+import {
+  STATE_TO_DB,
+  persistStepForEvent,
+  transitionEventForLastEvent,
+} from './orchestrator'
+import type { AgentEvent } from '~/shared/sse/events'
+
+const SessionFixed = Layer.succeed(SessionContext, { sessionId: 'rs_fail' })
+
+// Empty research-tool stubs — these tests don't drive the search path, so
+// nothing needs canned responses; we just have to satisfy the requirements
+// the catalog declares (Slice 11 added them).
+const TestEnv = Layer.mergeAll(
+  RepositoryInMemoryLive,
+  IdsTest,
+  SessionFixed,
+  BraveStub.layer([]),
+  Context7Stub.layer({}),
+  UrlFetcherStub.layer([]),
+)
+
+const catalog = makeCatalog(builtinTools)
+
+const completion = (
+  cmplId: string,
+  opts: {
+    content?: string
+    toolCalls?: ReadonlyArray<{
+      id: string
+      name: string
+      args: Record<string, unknown>
+    }>
+  },
+): OpenAI.ChatCompletion =>
+  ({
+    id: cmplId,
+    object: 'chat.completion',
+    created: 0,
+    model: 'm',
+    choices: [
+      {
+        index: 0,
+        message: {
+          role: 'assistant',
+          content: opts.content ?? '',
+          refusal: null,
+          tool_calls: opts.toolCalls?.map((c) => ({
+            id: c.id,
+            type: 'function',
+            function: {
+              name: c.name,
+              arguments: JSON.stringify(c.args),
+            },
+          })),
+        },
+        finish_reason: opts.toolCalls ? 'tool_calls' : 'stop',
+        logprobs: null,
+      },
+    ],
+  }) as OpenAI.ChatCompletion
+
+/**
+ * Drive the loop, persist each event through the orchestrator, then run
+ * the terminal transition. Returns the collected events for downstream
+ * assertions.
+ */
+const driveAndPersist = (
+  sessionId: string,
+  groqLayer: ReturnType<typeof GroqStub.layer>,
+) =>
+  Effect.gen(function* () {
+    const repo = yield* ResearchRepository
+    const stateRef = yield* Ref.make<SessionState>('RUNNING')
+    const lastEventRef = yield* Ref.make<AgentEvent | undefined>(undefined)
+
+    // Seed an active session row so the FAILED transition has something to
+    // update.
+    const millis0 = yield* Clock.currentTimeMillis
+    yield* repo.createSession({
+      id: sessionId,
+      initialPrompt: 'go',
+      status: ResearchSessionStatus.active,
+      ownerId: 'owner_test',
+      createdAt: new Date(millis0),
+      updatedAt: new Date(millis0),
+    })
+
+    const events = yield* Stream.runCollect(
+      runLoop({ prompt: 'go', groqRetryBaseDelayMs: 1 }, catalog).pipe(
+        Stream.tap((event) =>
+          Effect.gen(function* () {
+            yield* persistStepForEvent(sessionId, event)
+            yield* Ref.set(lastEventRef, event)
+          }),
+        ),
+      ),
+    ).pipe(Effect.provide(groqLayer))
+
+    const last = yield* Ref.get(lastEventRef)
+    const transitionEvent: SessionEvent | undefined =
+      last !== undefined ? transitionEventForLastEvent(last) : undefined
+    if (transitionEvent !== undefined) {
+      const current = yield* Ref.get(stateRef)
+      const next = yield* transition(current, transitionEvent).pipe(
+        Effect.orElseSucceed(() => current),
+      )
+      if (next !== current) {
+        const millis1 = yield* Clock.currentTimeMillis
+        yield* repo.setSessionStatus(
+          sessionId,
+          STATE_TO_DB[next],
+          new Date(millis1),
+        )
+        yield* Ref.set(stateRef, next)
+      }
+    }
+
+    return {
+      events: Chunk.toReadonlyArray(events) as ReadonlyArray<AgentEvent>,
+      finalState: yield* Ref.get(stateRef),
+    }
+  })
+
+describe('research orchestrator (slice 12)', () => {
+  it.live(
+    'persists a failure step + transitions to FAILED on terminal error/failed',
+    () =>
+      Effect.gen(function* () {
+        // 4 rate-limit responses → loop emits 3 retry events + 1 failed event,
+        // then halts.
+        const turns: ReadonlyArray<GroqStubTurn> = [
+          { _err: new GroqRateLimitError({}) },
+          { _err: new GroqRateLimitError({}) },
+          { _err: new GroqRateLimitError({}) },
+          { _err: new GroqRateLimitError({}) },
+        ]
+
+        const { events, finalState } = yield* driveAndPersist(
+          'rs_fail',
+          GroqStub.layer(turns),
+        )
+
+        // Sanity: loop produced an error/failed event last.
+        const last = events[events.length - 1]!
+        if (last.type !== 'error') throw new Error('expected error tail')
+        expect(last.kind).toBe('failed')
+
+        // FSM moved to FAILED.
+        expect(finalState).toBe('FAILED')
+
+        // Repo: session row reflects the FAILED state.
+        const repo = yield* ResearchRepository
+        const row = yield* repo.getSessionById('rs_fail')
+        expect(row.status).toBe(ResearchSessionStatus.failed)
+
+        // Repo: at least one step row written with status=failure and a
+        // non-null error message.
+        const steps = yield* repo.listStepsBySession('rs_fail')
+        const failure = steps.find(
+          (s) => s.status === ResearchStepStatus.failure,
+        )
+        expect(failure).toBeDefined()
+        expect(failure?.errorMessage).toMatch(/rate.?limit|429|retries exhausted/i)
+
+        // Each retry event also persisted (with status=success, since the
+        // loop is mid-recovery), and carries the reason.
+        const retries = steps.filter(
+          (s) =>
+            s.status === ResearchStepStatus.success &&
+            s.errorMessage !== null &&
+            /rate.?limit|429/i.test(s.errorMessage ?? ''),
+        )
+        expect(retries.length).toBe(3)
+      }).pipe(Effect.provide(TestEnv)),
+  )
+
+  it.effect(
+    'transitions to COMPLETED on terminal done event (happy path)',
+    () =>
+      Effect.gen(function* () {
+        const turns: ReadonlyArray<GroqStubTurn> = [
+          completion('c1', {
+            toolCalls: [
+              { id: 'tc1', name: 'finalize', args: { summary: 'shipped' } },
+            ],
+          }),
+        ]
+
+        const { finalState } = yield* driveAndPersist(
+          'rs_ok',
+          GroqStub.layer(turns),
+        )
+        expect(finalState).toBe('COMPLETED')
+
+        const repo = yield* ResearchRepository
+        const row = yield* repo.getSessionById('rs_ok')
+        expect(row.status).toBe(ResearchSessionStatus.completed)
+      }).pipe(Effect.provide(TestEnv)),
+  )
+
+  it.effect(
+    'transitions to WAITING_FOR_USER on terminal question_asked event',
+    () =>
+      Effect.gen(function* () {
+        const turns: ReadonlyArray<GroqStubTurn> = [
+          completion('c1', {
+            toolCalls: [
+              {
+                id: 'tc1',
+                name: 'askQuestion',
+                args: {
+                  question: 'TTL?',
+                  recommendation: '5min',
+                  rationale: 'hot reads',
+                },
+              },
+            ],
+          }),
+        ]
+
+        const { finalState } = yield* driveAndPersist(
+          'rs_pause',
+          GroqStub.layer(turns),
+        )
+        expect(finalState).toBe('WAITING_FOR_USER')
+
+        const repo = yield* ResearchRepository
+        const row = yield* repo.getSessionById('rs_pause')
+        expect(row.status).toBe(ResearchSessionStatus.waitingForUser)
+      }).pipe(Effect.provide(TestEnv)),
+  )
+})

--- a/src/shared/research/orchestrator.ts
+++ b/src/shared/research/orchestrator.ts
@@ -1,0 +1,84 @@
+/**
+ * Stream-orchestration helpers shared by the Durable Object and tests.
+ *
+ * The DO drains a `Stream<AgentEvent>` from the agent loop and, for each
+ * event, has to:
+ *
+ *   - persist a `research_steps` row that mirrors the event,
+ *   - decide what FSM event (if any) the *terminal* event implies.
+ *
+ * Both decisions are pure functions of the event shape, so they live here
+ * — the DO calls them one layer up but the tests can call them directly
+ * against the in-memory repo without spinning up a real DO.
+ */
+import { Effect } from 'effect'
+import type { RepositoryError } from '~/shared/domain/errors'
+import {
+  ResearchRepository,
+  type NewStep,
+} from '~/shared/infra/drizzle/repository'
+import { ResearchSessionStatus } from '~/shared/infra/drizzle/schema'
+import type { SessionEvent, SessionState } from '~/shared/session/state-machine'
+import type { AgentEvent } from '~/shared/sse/events'
+
+/**
+ * Mapping from FSM state → DB-encoded session status. Lives here (not in
+ * the DO) so the test orchestrator and the DO agree on the encoding.
+ */
+export const STATE_TO_DB: Record<SessionState, ResearchSessionStatus> = {
+  RUNNING: ResearchSessionStatus.active,
+  WAITING_FOR_USER: ResearchSessionStatus.waitingForUser,
+  COMPLETED: ResearchSessionStatus.completed,
+  FAILED: ResearchSessionStatus.failed,
+  ABANDONED: ResearchSessionStatus.abandoned,
+}
+
+/**
+ * Wrap an `AgentEvent` into the `NewStep` write shape the repository
+ * accepts. The repo then projects the event into the per-column row
+ * (deriving `errorMessage` from `error/*` events and choosing
+ * `status: failure` only on `error/failed`).
+ */
+export const eventToStep = (sessionId: string, event: AgentEvent): NewStep => ({
+  sessionId,
+  event,
+})
+
+/**
+ * Persist one step row through the repository. Effectful wrapper around
+ * `eventToStep`.
+ */
+export const persistStepForEvent = (
+  sessionId: string,
+  event: AgentEvent,
+): Effect.Effect<void, RepositoryError, ResearchRepository> =>
+  Effect.gen(function* () {
+    const repo = yield* ResearchRepository
+    yield* repo.appendStep(eventToStep(sessionId, event))
+  })
+
+/**
+ * Decide which FSM event (if any) the terminal stream event implies.
+ *
+ *   - question_asked → askQuestion
+ *   - error/failed   → fail
+ *   - done           → finalize
+ *
+ * Anything else → undefined (the host shouldn't transition; the loop
+ * either ended mid-stream and another tick will follow, or the event
+ * carries no transition semantics).
+ */
+export const transitionEventForLastEvent = (
+  event: AgentEvent,
+): SessionEvent | undefined => {
+  switch (event.type) {
+    case 'question_asked':
+      return 'askQuestion'
+    case 'done':
+      return 'finalize'
+    case 'error':
+      return event.kind === 'failed' ? 'fail' : undefined
+    default:
+      return undefined
+  }
+}

--- a/src/shared/sse/events.test.ts
+++ b/src/shared/sse/events.test.ts
@@ -43,6 +43,19 @@ const cases: ReadonlyArray<AgentEvent> = [
     content: 'make it dark',
   },
   { id: 6, type: 'done', finalText: 'all good' },
+  {
+    id: 7,
+    type: 'error',
+    kind: 'retry',
+    attempt: 2,
+    reason: 'Groq rate-limited (429)',
+  },
+  {
+    id: 8,
+    type: 'error',
+    kind: 'failed',
+    reason: 'Groq retries exhausted',
+  },
 ]
 
 describe('sse events', () => {

--- a/src/shared/sse/events.ts
+++ b/src/shared/sse/events.ts
@@ -71,6 +71,22 @@ export const DoneEvent = Schema.Struct({
 })
 export type DoneEvent = Schema.Schema.Type<typeof DoneEvent>
 
+/**
+ * `ErrorEvent` — surfaces transient retries during backoff windows
+ * (`kind: 'retry'`) and the final failure when the loop transitions to
+ * `FAILED` (`kind: 'failed'`). The frontend keys off `kind` to render a
+ * dismiss-able banner vs. a persistent one.
+ */
+export const ErrorEvent = Schema.Struct({
+  id: Schema.Number,
+  type: Schema.Literal('error'),
+  kind: Schema.Literal('retry', 'failed'),
+  /** Only present on retry events; 1-indexed attempt number. */
+  attempt: Schema.optional(Schema.Number),
+  reason: Schema.String,
+})
+export type ErrorEvent = Schema.Schema.Type<typeof ErrorEvent>
+
 export const AgentEvent = Schema.Union(
   AgentThinkingEvent,
   ToolInvokedEvent,
@@ -78,6 +94,7 @@ export const AgentEvent = Schema.Union(
   QuestionAskedEvent,
   PrdSectionWrittenEvent,
   DoneEvent,
+  ErrorEvent,
 )
 export type AgentEvent = Schema.Schema.Type<typeof AgentEvent>
 


### PR DESCRIPTION
## Summary

- Add session ownership via `owner_id` column and cookie-based access control (Slice 6 foundation)
- Implement error handling with retries and tool-call repair in agent loop (3 max retries with exponential backoff)
- Add research tool implementations: Brave Search (`webSearch`), Context7 (`searchLibraryDocs`), and URL fetcher (`readUrl`)
- Add SSE event replay on EventSource reconnect via `event` column in `research_steps` table (Slice 5)
- Add session abandonment on 24-hour timeout
- Create `SessionView` component for live session viewing with PRD panel and event timeline
- Extend README with required secrets: `SESSION_COOKIE_SECRET`, `BRAVE_API_KEY`

## Testing

- Unit tests added for auth (cookie, header, access control), research tools (Brave, Context7, URL fetcher), and orchestration
- Integration tests for session access control and SSE replay
- Agent loop tests updated for retry/repair scenarios and error event handling
- Session view component tested with access denial and error banners
- Not run: end-to-end session flow with live agent execution