### PR TITLE
Slice 13: Edge rate limiting and session access control

### DIFF
--- a/alchemy.run.ts
+++ b/alchemy.run.ts
@@ -5,6 +5,7 @@ import {
   D1Database,
   DurableObjectNamespace,
   Ai,
+  RateLimit,
 } from 'alchemy/cloudflare'
 
 const app = await alchemy('ghaudit', {
@@ -16,6 +17,30 @@ const ai = Ai()
 const d1 = await D1Database('ghaudit_d1', {
   dev: { remote: false },
   migrationsDir: './drizzle/migrations',
+})
+
+/*
+ * Per-IP rate limits at the worker edge.
+ *
+ *   - Session creation is the expensive operation (mints a DO, kicks off
+ *     a Groq-bounded loop). The Groq free tier is ~1000 requests/day,
+ *     so 10 sessions/min/IP keeps ~6 simultaneous IPs comfortably within
+ *     the daily budget.
+ *
+ *   - Answer submission is normal user activity inside an active session
+ *     and isn't itself a Groq cost driver, so the limit is more permissive.
+ *
+ * `namespace_id` is the binding-local identifier that the runtime uses
+ * to namespace the counters.
+ */
+const sessionRateLimit = RateLimit({
+  namespace_id: 1001,
+  simple: { limit: 10, period: 60 },
+})
+
+const answerRateLimit = RateLimit({
+  namespace_id: 1002,
+  simple: { limit: 60, period: 60 },
 })
 
 export const worker = await TanStackStart('worker', {
@@ -44,6 +69,8 @@ export const worker = await TanStackStart('worker', {
       className: 'ResearchDO',
       sqlite: true,
     }),
+    SESSION_RATELIMIT: sessionRateLimit,
+    ANSWER_RATELIMIT: answerRateLimit,
   },
 })
 

--- a/src/components/question-card.tsx
+++ b/src/components/question-card.tsx
@@ -49,7 +49,20 @@ export function QuestionCard({
       setAnswered(true)
       onAnswered?.()
     } catch (err) {
-      setError((err as Error).message)
+      const tagged = err as {
+        readonly tag?: string
+        readonly retryAfterSeconds?: number
+      }
+      // Rate-limit messages are friendlier as "try again in N seconds"
+      // than the raw tagged-error string. Other errors keep the
+      // generic `err.message` shape (`<tag>: <detail>`).
+      if (tagged.tag === 'RequestRateLimited' && tagged.retryAfterSeconds) {
+        setError(
+          `Rate limited — try again in ${tagged.retryAfterSeconds} seconds.`,
+        )
+      } else {
+        setError((err as Error).message)
+      }
     } finally {
       setSubmitting(false)
     }

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -38,7 +38,7 @@ function App() {
         params: { id: created.sessionId },
       })
     } catch (err) {
-      setError((err as Error).message)
+      setError(formatError(err))
     } finally {
       setSubmitting(false)
     }
@@ -74,4 +74,24 @@ function App() {
       )}
     </main>
   )
+}
+
+/**
+ * Per-route formatter for thrown server-fn errors. We only special-case
+ * `RequestRateLimited` here so the user sees a "try again in N seconds"
+ * message instead of the raw tagged-error string. Everything else falls
+ * back to `err.message`, which already carries `<tag>: <detail>`.
+ *
+ * The shape `{ tag, retryAfterSeconds }` is stamped on by `renderError`
+ * (see `~/shared/domain/http-errors.ts`).
+ */
+function formatError(err: unknown): string {
+  const tagged = err as {
+    readonly tag?: string
+    readonly retryAfterSeconds?: number
+  }
+  if (tagged.tag === 'RequestRateLimited' && tagged.retryAfterSeconds) {
+    return `Rate limited — try again in ${tagged.retryAfterSeconds} seconds.`
+  }
+  return (err as Error).message
 }

--- a/src/server-fns/session.ts
+++ b/src/server-fns/session.ts
@@ -21,6 +21,10 @@
  * Cloudflare env, the program runs, the result is rendered. Worker
  * env access goes through `cloudflare:workers`'s `env` import — the
  * server-function context doesn't expose env directly.
+ *
+ * Slice 13: both endpoints gate through the worker-edge `RateLimiter`
+ * before doing any DB / DO work, keyed by `cf-connecting-ip`. Exhaustion
+ * surfaces as `RequestRateLimited` → 429 + `Retry-After`.
  */
 import { createServerFn } from '@tanstack/react-start'
 import {
@@ -37,12 +41,11 @@ import {
   buildSessionOwnerCookie,
   readSessionOwnerCookie,
 } from '~/shared/auth/header'
-import { type AppError, statusForError } from '~/shared/domain/errors'
+import { type AppError } from '~/shared/domain/errors'
+import { renderError, type ServerFnError } from '~/shared/domain/http-errors'
+import { RateLimiter } from '~/shared/infra/ratelimit/client'
 import { createSession } from '~/shared/research/session'
-import {
-  EventStreamUrlBuilderLive,
-  MainLive,
-} from '~/shared/runtime/main'
+import { EventStreamUrlBuilderLive, MainLive } from '~/shared/runtime/main'
 
 /* ------------------------------------------------------------------ *
  * Input schemas
@@ -60,28 +63,29 @@ const SubmitAnswerInput = Schema.Struct({
 })
 
 /* ------------------------------------------------------------------ *
- * Error rendering — AppError → throwable Error with `tag` + `status`
- * stamped on so the client can branch on them.
+ * Error rendering — `renderError` lives in `~/shared/domain/http-errors`
+ * (single source of truth for AppError → HTTP shape). `renderCause` is
+ * server-fn-specific because the worker entry has its own
+ * cause-rendering path (`Cause.pretty` directly into a 500 Response).
  * ------------------------------------------------------------------ */
-
-interface ServerFnError extends Error {
-  readonly tag: string
-  readonly status: number
-}
-
-const renderError = (err: AppError): ServerFnError => {
-  const detail = 'reason' in err ? err.reason : ''
-  const message = detail ? `${err._tag}: ${detail}` : err._tag
-  const e = new Error(message) as ServerFnError
-  Object.assign(e, { tag: err._tag, status: statusForError(err) })
-  return e
-}
 
 const renderCause = (cause: Cause.Cause<unknown>): ServerFnError => {
   const e = new Error(`internal error: ${Cause.pretty(cause)}`) as ServerFnError
   Object.assign(e, { tag: 'InternalError', status: 500 })
   return e
 }
+
+/* ------------------------------------------------------------------ *
+ * IP extraction
+ *
+ * Cloudflare populates `cf-connecting-ip` for inbound requests on the
+ * edge. Local dev (wrangler/miniflare) sometimes omits it; we fall back
+ * to a sentinel so the rate-limit gate still functions (one shared
+ * bucket for all unidentified clients).
+ * ------------------------------------------------------------------ */
+
+const ipFromRequest = (request: Request): string =>
+  request.headers.get('cf-connecting-ip') ?? 'unknown'
 
 /* ------------------------------------------------------------------ *
  * Runtime boundary
@@ -93,14 +97,24 @@ const renderCause = (cause: Cause.Cause<unknown>): ServerFnError => {
  * around it.
  *
  * The base layer (MainLive + OwnerCookieLive) is also shared — both
- * RPC endpoints need DB + cookie verification. `createSessionFn` adds
- * the per-request `EventStreamUrlBuilderLive` on top.
+ * RPC endpoints need DB + cookie verification + rate-limit gating.
+ * `createSessionFn` adds the per-request `EventStreamUrlBuilderLive`
+ * on top.
  *
  * `requireCookieSecret` reads the env at call-time (not at module load)
  * so a missing secret surfaces as an `Error` thrown from the server-fn
  * boundary the user actually hit, rather than a worker-bootstrap
  * exception buried in platform logs.
  * ------------------------------------------------------------------ */
+
+interface RateLimitEnv {
+  readonly SESSION_RATELIMIT: {
+    readonly limit: (o: { key: string }) => Promise<{ success: boolean }>
+  }
+  readonly ANSWER_RATELIMIT: {
+    readonly limit: (o: { key: string }) => Promise<{ success: boolean }>
+  }
+}
 
 const requireCookieSecret = (): string => {
   const e = env as unknown as { SESSION_COOKIE_SECRET?: string }
@@ -110,11 +124,21 @@ const requireCookieSecret = (): string => {
   return e.SESSION_COOKIE_SECRET
 }
 
-const baseSessionLayer = () =>
-  Layer.merge(
-    MainLive({ D1: env.D1, groq: { apiKey: env.GROQ_API_KEY } }),
+const baseSessionLayer = () => {
+  const rl = env as unknown as RateLimitEnv
+  return Layer.merge(
+    MainLive({
+      D1: env.D1,
+      groq: { apiKey: env.GROQ_API_KEY },
+      rateLimit: {
+        sessionCreate: rl.SESSION_RATELIMIT,
+        answerSubmit: rl.ANSWER_RATELIMIT,
+        periodSeconds: 60,
+      },
+    }),
     OwnerCookieLive(requireCookieSecret()),
   )
+}
 
 const runServerFn = <A, R>(
   layer: Layer.Layer<R, AppError>,
@@ -144,16 +168,20 @@ interface CreateSessionResponse {
 export const createSessionFn = createServerFn({ method: 'POST' })
   .inputValidator(Schema.decodeUnknownSync(CreateSessionInput))
   .handler(async ({ data }): Promise<CreateSessionResponse> => {
-    const url = new URL(getRequest().url)
+    const request = getRequest()
+    const url = new URL(request.url)
+    const key = ipFromRequest(request)
     const layer = Layer.merge(
       baseSessionLayer(),
-      EventStreamUrlBuilderLive(
-        (id) => `${url.origin}/session/${id}/stream`,
-      ),
+      EventStreamUrlBuilderLive((id) => `${url.origin}/session/${id}/stream`),
     )
     const { created, signed } = await runServerFn(
       layer,
       Effect.gen(function* () {
+        // Slice 13: rate-limit before any DB work so an exhausted
+        // client can't burn create-session budget on D1 / Groq.
+        const rl = yield* RateLimiter
+        yield* rl.checkSessionCreate(key)
         const created = yield* createSession(data)
         const cookie = yield* OwnerCookie
         const signed = yield* cookie.sign(created.ownerId)
@@ -198,9 +226,7 @@ interface AnswerErrorBody {
   readonly detail?: string
 }
 
-const isAnswerError = (
-  body: unknown,
-): body is AnswerErrorBody =>
+const isAnswerError = (body: unknown): body is AnswerErrorBody =>
   typeof body === 'object' &&
   body !== null &&
   'error' in body &&
@@ -219,15 +245,22 @@ interface ResearchDONamespace {
 export const submitAnswerFn = createServerFn({ method: 'POST' })
   .inputValidator(Schema.decodeUnknownSync(SubmitAnswerInput))
   .handler(async ({ data }): Promise<AnswerSuccessBody> => {
-    // Cookie check happens *before* we call into the DO. The DO has no
-    // notion of cookies; ownership is enforced at the worker / server-fn
-    // boundary against the row's owner_id.
+    const request = getRequest()
+    const key = ipFromRequest(request)
+    // Slice 13 + Slice 6: rate-limit gate runs first, then cookie
+    // ownership check. Both happen *before* we call into the DO. The
+    // DO has no notion of cookies; ownership is enforced at the
+    // worker / server-fn boundary against the row's owner_id.
     const signedCookie = readSessionOwnerCookie(getRequestHeader('cookie'))
     await runServerFn(
       baseSessionLayer(),
-      assertSessionAccess({
-        sessionId: data.sessionId,
-        signedCookie: signedCookie as Option.Option<string>,
+      Effect.gen(function* () {
+        const rl = yield* RateLimiter
+        yield* rl.checkAnswerSubmit(key)
+        yield* assertSessionAccess({
+          sessionId: data.sessionId,
+          signedCookie: signedCookie as Option.Option<string>,
+        })
       }),
     )
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -26,10 +26,8 @@ import { Cause, Effect, Layer } from 'effect'
 import { assertSessionAccess } from '~/shared/auth/access'
 import { OwnerCookie, OwnerCookieLive } from '~/shared/auth/cookie'
 import { readSessionOwnerCookie } from '~/shared/auth/header'
-import {
-  type AppError,
-  statusForError,
-} from '~/shared/domain/errors'
+import { type AppError } from '~/shared/domain/errors'
+import { toErrorResponse } from '~/shared/domain/http-errors'
 import { ResearchRepository } from '~/shared/infra/drizzle/repository'
 import { MainLive } from '~/shared/runtime/main'
 
@@ -99,10 +97,7 @@ interface ResearchDONamespace {
   readonly get: (id: unknown) => { fetch: typeof fetch }
 }
 
-const doStub = (
-  env: Env,
-  sessionId: string,
-): { fetch: typeof fetch } => {
+const doStub = (env: Env, sessionId: string): { fetch: typeof fetch } => {
   const ns = env.RESEARCH_DO as unknown as ResearchDONamespace
   return ns.get(ns.idFromName(sessionId))
 }
@@ -110,10 +105,16 @@ const doStub = (
 /* ------------------------------------------------------------------ *
  * Layer composition (per-request)
  *
- * Both remaining handlers only need `ResearchRepository`; the rest of
- * `MainLive` (Ids, Groq) is over-provided. We keep the full live layer
- * so the worker entry stays a one-liner consumer of `MainLive` and the
- * shape mirrors what the DO does.
+ * `/stream` and `/prd` only need `ResearchRepository` + `OwnerCookie`;
+ * `MainLive`'s other services (Ids, Groq, Brave, Context7, UrlFetcher,
+ * RateLimiter) are over-provided. We keep the full live layer so the
+ * worker entry stays a one-liner consumer of `MainLive` and the shape
+ * mirrors what the DO does.
+ *
+ * Slice 13 rate-limit bindings (SESSION_RATELIMIT, ANSWER_RATELIMIT)
+ * gate the two server-fn endpoints (`/session`, `/session/:id/answer`),
+ * not the routes handled here — so we use `MainLive`'s `allowAlways`
+ * fallback rather than threading the env bindings through.
  * ------------------------------------------------------------------ */
 
 const runRequest = (
@@ -151,15 +152,6 @@ const runRequest = (
     ),
   )
 }
-
-const toErrorResponse = (err: AppError): Response =>
-  Response.json(
-    {
-      error: err._tag,
-      detail: 'reason' in err ? err.reason : undefined,
-    },
-    { status: statusForError(err) },
-  )
 
 /* ------------------------------------------------------------------ *
  * Entry

--- a/src/shared/domain/errors.test.ts
+++ b/src/shared/domain/errors.test.ts
@@ -1,0 +1,17 @@
+/**
+ * Status-mapping tests for `statusForError`. The status table is the
+ * single source of truth at every HTTP boundary, so each tag's mapping
+ * is exercised explicitly.
+ */
+import { describe, it, expect } from '@effect/vitest'
+import { RequestRateLimited, statusForError } from './errors'
+
+describe('statusForError', () => {
+  it('maps RequestRateLimited to 429', () => {
+    const e = new RequestRateLimited({
+      scope: 'session-create',
+      retryAfterSeconds: 60,
+    })
+    expect(statusForError(e)).toBe(429)
+  })
+})

--- a/src/shared/domain/errors.ts
+++ b/src/shared/domain/errors.ts
@@ -18,9 +18,7 @@ import type { ParseResult } from 'effect'
  * Repository
  * ------------------------------------------------------------------ */
 
-export class RepositoryNotFound extends Data.TaggedError(
-  'RepositoryNotFound',
-)<{
+export class RepositoryNotFound extends Data.TaggedError('RepositoryNotFound')<{
   readonly entity: string
   readonly id: string
 }> {}
@@ -63,9 +61,7 @@ export class GroqNetworkError extends Data.TaggedError('GroqNetworkError')<{
   readonly cause: unknown
 }> {}
 
-export class GroqRateLimitError extends Data.TaggedError(
-  'GroqRateLimitError',
-)<{
+export class GroqRateLimitError extends Data.TaggedError('GroqRateLimitError')<{
   readonly retryAfterSeconds?: number
 }> {}
 
@@ -178,9 +174,7 @@ export type UrlFetcherError =
  * Tools
  * ------------------------------------------------------------------ */
 
-export class ToolInputJsonError extends Data.TaggedError(
-  'ToolInputJsonError',
-)<{
+export class ToolInputJsonError extends Data.TaggedError('ToolInputJsonError')<{
   readonly toolName: string
   readonly raw: string
   readonly cause: unknown
@@ -194,9 +188,7 @@ export class ToolInputParseError extends Data.TaggedError(
   readonly cause: ParseResult.ParseError
 }> {}
 
-export class ToolExecutionError extends Data.TaggedError(
-  'ToolExecutionError',
-)<{
+export class ToolExecutionError extends Data.TaggedError('ToolExecutionError')<{
   readonly toolName: string
   readonly cause: unknown
 }> {}
@@ -220,6 +212,17 @@ export class StateTransitionError extends Data.TaggedError(
 )<{
   readonly from: string
   readonly event: string
+}> {}
+
+/* ------------------------------------------------------------------ *
+ * Edge rate limiting
+ * ------------------------------------------------------------------ */
+
+export type RateLimitScope = 'session-create' | 'answer-submit'
+
+export class RequestRateLimited extends Data.TaggedError('RequestRateLimited')<{
+  readonly scope: RateLimitScope
+  readonly retryAfterSeconds: number
 }> {}
 
 /* ------------------------------------------------------------------ *
@@ -286,6 +289,7 @@ export type AppError =
   | BraveError
   | Context7Error
   | UrlFetcherError
+  | RequestRateLimited
 
 export const statusForError = (e: AppError): number => {
   switch (e._tag) {
@@ -308,6 +312,7 @@ export const statusForError = (e: AppError): number => {
       return 502
     case 'GroqRateLimitError':
     case 'BraveRateLimitError':
+    case 'RequestRateLimited':
       return 429
     case 'GroqNetworkError':
     case 'GroqApiError':

--- a/src/shared/domain/http-errors.test.ts
+++ b/src/shared/domain/http-errors.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Boundary tests for the HTTP error renderers. The renderers translate
+ * tagged `AppError`s into:
+ *
+ *   - `renderError`     → a `Error` for `throw` from a TanStack server fn
+ *                         (status code stamped on so the client can branch)
+ *   - `toErrorResponse` → a `Response` for the raw worker entry
+ *                         (status + headers, JSON body)
+ *
+ * These exist as a shared module rather than duplicated in
+ * `server.ts` / `server-fns/session.ts` so error semantics live in one
+ * place — adding a new error tag means updating one file.
+ */
+import { describe, it, expect } from '@effect/vitest'
+import { Conflict, RequestRateLimited } from './errors'
+import { renderError, toErrorResponse } from './http-errors'
+
+describe('renderError (server-fn boundary)', () => {
+  it('stamps tag and status from the error', () => {
+    const e = renderError(new Conflict({ reason: 'already done' }))
+    expect(e.tag).toBe('Conflict')
+    expect(e.status).toBe(409)
+  })
+
+  it('attaches retryAfterSeconds for RequestRateLimited', () => {
+    const e = renderError(
+      new RequestRateLimited({
+        scope: 'session-create',
+        retryAfterSeconds: 60,
+      }),
+    )
+    expect(e.tag).toBe('RequestRateLimited')
+    expect(e.status).toBe(429)
+    expect(e.retryAfterSeconds).toBe(60)
+  })
+})
+
+describe('toErrorResponse (raw HTTP boundary)', () => {
+  it('renders RequestRateLimited as 429 with a Retry-After header', async () => {
+    const res = toErrorResponse(
+      new RequestRateLimited({
+        scope: 'session-create',
+        retryAfterSeconds: 60,
+      }),
+    )
+    expect(res.status).toBe(429)
+    expect(res.headers.get('Retry-After')).toBe('60')
+    const body = (await res.json()) as { error: string }
+    expect(body.error).toBe('RequestRateLimited')
+  })
+
+  it('does NOT attach Retry-After to non-rate-limit errors', () => {
+    const res = toErrorResponse(new Conflict({ reason: 'already done' }))
+    expect(res.status).toBe(409)
+    expect(res.headers.get('Retry-After')).toBeNull()
+  })
+})

--- a/src/shared/domain/http-errors.ts
+++ b/src/shared/domain/http-errors.ts
@@ -1,0 +1,56 @@
+/**
+ * Single point of translation between tagged `AppError`s and HTTP shapes.
+ *
+ * Two shapes, because the codebase has two boundaries that surface
+ * errors:
+ *
+ *   - `renderError`     — TanStack server-fn boundary. Server fns can
+ *                         only signal failure by `throw`-ing, so we
+ *                         convert to an `Error` with `tag` / `status` /
+ *                         `retryAfterSeconds` stamped on.
+ *
+ *   - `toErrorResponse` — raw worker-entry boundary (`server.ts` and the
+ *                         `do/research.ts` HTTP routes). Returns a real
+ *                         `Response` with status, JSON body, and
+ *                         `Retry-After` when the error carries one.
+ *
+ * Centralising these here means: one place to add a new error tag, one
+ * place to add a new HTTP semantics rule (e.g. `Retry-After`).
+ */
+import { type AppError, statusForError } from './errors'
+
+export interface ServerFnError extends Error {
+  readonly tag: string
+  readonly status: number
+  readonly retryAfterSeconds?: number
+}
+
+export const renderError = (err: AppError): ServerFnError => {
+  const detail = 'reason' in err ? err.reason : ''
+  const message = detail ? `${err._tag}: ${detail}` : err._tag
+  const e = new Error(message) as Error & {
+    tag: string
+    status: number
+    retryAfterSeconds?: number
+  }
+  e.tag = err._tag
+  e.status = statusForError(err)
+  if (err._tag === 'RequestRateLimited') {
+    e.retryAfterSeconds = err.retryAfterSeconds
+  }
+  return e
+}
+
+export const toErrorResponse = (err: AppError): Response => {
+  const headers: Record<string, string> = {}
+  if (err._tag === 'RequestRateLimited') {
+    headers['Retry-After'] = String(err.retryAfterSeconds)
+  }
+  return Response.json(
+    {
+      error: err._tag,
+      detail: 'reason' in err ? err.reason : undefined,
+    },
+    { status: statusForError(err), headers },
+  )
+}

--- a/src/shared/infra/ratelimit/client.test.ts
+++ b/src/shared/infra/ratelimit/client.test.ts
@@ -1,0 +1,139 @@
+/**
+ * `RateLimiter` is a deep module: callers say `rl.checkSessionCreate(key)`
+ * and never touch the underlying Cloudflare binding shape, the key
+ * derivation, or the `{ success: boolean }` → tagged-error translation.
+ *
+ * These tests provide hand-rolled fake bindings that match the
+ * Cloudflare `RateLimit` runtime shape (`limit({ key }) → { success }`).
+ * The fakes are deliberately not Effect services — they live on the
+ * "Cloudflare side" of the seam.
+ */
+import { describe, it, expect } from '@effect/vitest'
+import { Cause, Effect, Exit } from 'effect'
+import { RequestRateLimited } from '~/shared/domain/errors'
+import { RateLimiter, RateLimiterLive } from './client'
+
+interface FakeBinding {
+  readonly limit: (options: { key: string }) => Promise<{ success: boolean }>
+}
+
+const stubBinding = (success: boolean): FakeBinding => ({
+  limit: async () => ({ success }),
+})
+
+describe('RateLimiter.checkSessionCreate', () => {
+  it.effect(
+    'fails with RequestRateLimited(scope=session-create, retryAfterSeconds=60) when binding denies',
+    () =>
+      Effect.gen(function* () {
+        const exit = yield* Effect.exit(
+          Effect.gen(function* () {
+            const rl = yield* RateLimiter
+            yield* rl.checkSessionCreate('1.2.3.4')
+          }),
+        )
+        expect(Exit.isFailure(exit)).toBe(true)
+        if (Exit.isFailure(exit)) {
+          const failure = Cause.failureOption(exit.cause)
+          expect(failure._tag).toBe('Some')
+          if (failure._tag === 'Some') {
+            expect(failure.value).toBeInstanceOf(RequestRateLimited)
+            expect(failure.value.scope).toBe('session-create')
+            expect(failure.value.retryAfterSeconds).toBe(60)
+          }
+        }
+      }).pipe(
+        Effect.provide(
+          RateLimiterLive({
+            sessionCreate: stubBinding(false),
+            answerSubmit: stubBinding(true),
+            periodSeconds: 60,
+          }),
+        ),
+      ),
+  )
+
+  it.effect('succeeds when the binding allows the request', () =>
+    Effect.gen(function* () {
+      const rl = yield* RateLimiter
+      // The success of the Effect itself is the assertion — if the
+      // service threw `RequestRateLimited` here, this expression
+      // would fail with that error (R contains it, so it can't escape).
+      yield* rl.checkSessionCreate('1.2.3.4')
+    }).pipe(
+      Effect.provide(
+        RateLimiterLive({
+          sessionCreate: stubBinding(true),
+          answerSubmit: stubBinding(false),
+          periodSeconds: 60,
+        }),
+      ),
+    ),
+  )
+})
+
+describe('RateLimiter binding routing', () => {
+  it.effect(
+    'checkAnswerSubmit fails with scope=answer-submit (uses answer binding, not session binding)',
+    () =>
+      Effect.gen(function* () {
+        const exit = yield* Effect.exit(
+          Effect.gen(function* () {
+            const rl = yield* RateLimiter
+            yield* rl.checkAnswerSubmit('1.2.3.4')
+          }),
+        )
+        expect(Exit.isFailure(exit)).toBe(true)
+        if (Exit.isFailure(exit)) {
+          const failure = Cause.failureOption(exit.cause)
+          if (failure._tag === 'Some') {
+            expect(failure.value).toBeInstanceOf(RequestRateLimited)
+            expect(failure.value.scope).toBe('answer-submit')
+          }
+        }
+      }).pipe(
+        // The session binding is *open* (true) and the answer binding is
+        // *closed* (false). The only way the test fails with
+        // scope=answer-submit is if the service routed through the
+        // answer binding, not the session one.
+        Effect.provide(
+          RateLimiterLive({
+            sessionCreate: stubBinding(true),
+            answerSubmit: stubBinding(false),
+            periodSeconds: 60,
+          }),
+        ),
+      ),
+  )
+})
+
+describe('RateLimiter key forwarding', () => {
+  it.effect("passes the caller's key through to the binding", () => {
+    const calls: Array<{ binding: 'session' | 'answer'; key: string }> = []
+    const recordingBinding = (which: 'session' | 'answer'): FakeBinding => ({
+      limit: async ({ key }) => {
+        calls.push({ binding: which, key })
+        return { success: true }
+      },
+    })
+
+    return Effect.gen(function* () {
+      const rl = yield* RateLimiter
+      yield* rl.checkSessionCreate('203.0.113.7')
+      yield* rl.checkAnswerSubmit('198.51.100.42')
+
+      expect(calls).toEqual([
+        { binding: 'session', key: '203.0.113.7' },
+        { binding: 'answer', key: '198.51.100.42' },
+      ])
+    }).pipe(
+      Effect.provide(
+        RateLimiterLive({
+          sessionCreate: recordingBinding('session'),
+          answerSubmit: recordingBinding('answer'),
+          periodSeconds: 60,
+        }),
+      ),
+    )
+  })
+})

--- a/src/shared/infra/ratelimit/client.ts
+++ b/src/shared/infra/ratelimit/client.ts
@@ -1,0 +1,85 @@
+/**
+ * `RateLimiter` — Effect service for the worker-edge rate-limit seam.
+ *
+ * Public surface (intentionally narrow):
+ *   - `checkSessionCreate(key)` — gate `POST /session`
+ *   - `checkAnswerSubmit(key)`  — gate `POST /session/:id/answer/:qid`
+ *
+ * Both fail with `RequestRateLimited` when the underlying Cloudflare
+ * binding returns `{ success: false }`. Callers never see the binding,
+ * never see the success/failure shape, never compute the `Retry-After`
+ * — the service owns all of that.
+ *
+ * `Retry-After` is derived from the layer's `periodSeconds` (the same
+ * value configured on the binding in `alchemy.run.ts`). The CF binding
+ * itself doesn't return a retry-after, so this is a deliberate choice:
+ * we tell the client "wait one full window" rather than guessing.
+ */
+import { Context, Effect, Layer } from 'effect'
+import { RequestRateLimited } from '~/shared/domain/errors'
+
+/**
+ * Minimal shape of the Cloudflare `RateLimit` runtime binding.
+ * Re-declared rather than imported from `@cloudflare/workers-types`
+ * so tests can hand-roll a fake without dragging the binding type in.
+ */
+export interface RateLimitBinding {
+  readonly limit: (options: {
+    readonly key: string
+  }) => Promise<{ readonly success: boolean }>
+}
+
+export class RateLimiter extends Context.Tag('RateLimiter')<
+  RateLimiter,
+  {
+    readonly checkSessionCreate: (
+      key: string,
+    ) => Effect.Effect<void, RequestRateLimited>
+    readonly checkAnswerSubmit: (
+      key: string,
+    ) => Effect.Effect<void, RequestRateLimited>
+  }
+>() {}
+
+export interface RateLimiterLiveOptions {
+  readonly sessionCreate: RateLimitBinding
+  readonly answerSubmit: RateLimitBinding
+  readonly periodSeconds: number
+}
+
+/**
+ * Live layer. Each `check*` call hits the corresponding binding and
+ * translates `{ success: false }` into a tagged failure.
+ */
+export const RateLimiterLive = (
+  options: RateLimiterLiveOptions,
+): Layer.Layer<RateLimiter> =>
+  Layer.succeed(
+    RateLimiter,
+    RateLimiter.of({
+      checkSessionCreate: (key) =>
+        Effect.gen(function* () {
+          const outcome = yield* Effect.promise(() =>
+            options.sessionCreate.limit({ key }),
+          )
+          if (!outcome.success) {
+            return yield* new RequestRateLimited({
+              scope: 'session-create',
+              retryAfterSeconds: options.periodSeconds,
+            })
+          }
+        }),
+      checkAnswerSubmit: (key) =>
+        Effect.gen(function* () {
+          const outcome = yield* Effect.promise(() =>
+            options.answerSubmit.limit({ key }),
+          )
+          if (!outcome.success) {
+            return yield* new RequestRateLimited({
+              scope: 'answer-submit',
+              retryAfterSeconds: options.periodSeconds,
+            })
+          }
+        }),
+    }),
+  )

--- a/src/shared/research/session.ratelimit.integration.test.ts
+++ b/src/shared/research/session.ratelimit.integration.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Integration test for the rate-limited `POST /session` pipeline.
+ *
+ * Reconstructs the same composition the server-fn handler uses:
+ *
+ *   1. `RateLimiter.checkSessionCreate(key)` — gate
+ *   2. `createSession(data)`                 — use case
+ *   3. `renderError(...)`                    — boundary translation
+ *
+ * The vitest environment is `node`, so we can't run this against a real
+ * Cloudflare RateLimit binding. Instead we provide a fake binding whose
+ * `limit({ key })` returns `{ success: true }` for the first N calls
+ * and `{ success: false }` thereafter — the same observable shape a
+ * real binding would produce when the bucket exhausts.
+ *
+ * What this test pins down (that the unit tests don't):
+ *   - The rate-limit check happens *before* the session row is written
+ *     (binding denies → no row in repository).
+ *   - On exhaustion the server-fn error envelope carries
+ *     status=429 and retryAfterSeconds=60 (what the client branches on).
+ */
+import { describe, it, expect } from '@effect/vitest'
+import { Cause, Effect, Exit, Layer } from 'effect'
+import { type AppError, RequestRateLimited } from '~/shared/domain/errors'
+import { renderError, type ServerFnError } from '~/shared/domain/http-errors'
+import { IdsLive } from '~/shared/domain/ids'
+import { RepositoryInMemoryLive } from '~/shared/infra/drizzle/repository'
+import {
+  RateLimiter,
+  RateLimiterLive,
+  type RateLimitBinding,
+} from '~/shared/infra/ratelimit/client'
+import { createSession } from './session'
+import { EventStreamUrlBuilderLive } from '~/shared/runtime/main'
+
+/**
+ * Fake binding that approximates Cloudflare's behaviour: allows up to
+ * `limit` calls, denies after that. Keys are ignored — a real binding
+ * would scope by key, but the test only spams one IP.
+ */
+const exhaustingBinding = (limit: number): RateLimitBinding => {
+  let count = 0
+  return {
+    limit: async () => {
+      count += 1
+      return { success: count <= limit }
+    },
+  }
+}
+
+const alwaysAllow: RateLimitBinding = {
+  limit: async () => ({ success: true }),
+}
+
+const TestLayer = (sessionCreate: RateLimitBinding) =>
+  Layer.mergeAll(
+    IdsLive,
+    RepositoryInMemoryLive,
+    EventStreamUrlBuilderLive((id) => `/session/${id}/stream`),
+    RateLimiterLive({
+      sessionCreate,
+      answerSubmit: alwaysAllow,
+      periodSeconds: 60,
+    }),
+  )
+
+/**
+ * Mirrors the server-fn composition. Kept inline rather than extracted
+ * into production code so the production module stays free of HTTP
+ * concerns — the wrapper is only meaningful at the request boundary.
+ */
+const ratelimitedCreateSession = (
+  key: string,
+  input: { initialPrompt: string },
+) =>
+  Effect.gen(function* () {
+    const rl = yield* RateLimiter
+    yield* rl.checkSessionCreate(key)
+    return yield* createSession(input)
+  })
+
+describe('POST /session — rate-limited pipeline', () => {
+  it.effect(
+    'spam past the limit: first N requests succeed, (N+1)th fails with 429 + Retry-After=60',
+    () =>
+      Effect.gen(function* () {
+        const limit = 3
+
+        // The first `limit` requests should succeed: each writes a row
+        // and returns a session id.
+        for (let i = 0; i < limit; i += 1) {
+          const result = yield* ratelimitedCreateSession('1.2.3.4', {
+            initialPrompt: `attempt ${i + 1}`,
+          })
+          expect(result.sessionId).toMatch(/^rs_/)
+        }
+
+        // The (limit+1)th request fails at the rate-limit gate. The
+        // gate runs before `createSession`, so the failure value is the
+        // tagged `RequestRateLimited` (no repository error mixed in).
+        const exit = yield* Effect.exit(
+          ratelimitedCreateSession('1.2.3.4', { initialPrompt: 'overflow' }),
+        )
+        expect(Exit.isFailure(exit)).toBe(true)
+        if (Exit.isFailure(exit)) {
+          const failure = Cause.failureOption(exit.cause)
+          expect(failure._tag).toBe('Some')
+          if (failure._tag === 'Some') {
+            // Tagged-error invariant: `RequestRateLimited` here proves
+            // the gate fired *and* createSession was not reached
+            // (createSession's R can't produce this tag).
+            expect(failure.value).toBeInstanceOf(RequestRateLimited)
+
+            // Render through the server-fn boundary translator. This
+            // is exactly what the handler does: AppError → ServerFnError.
+            const rendered: ServerFnError = renderError(
+              failure.value as AppError,
+            )
+            expect(rendered.tag).toBe('RequestRateLimited')
+            expect(rendered.status).toBe(429)
+            expect(rendered.retryAfterSeconds).toBe(60)
+          }
+        }
+      }).pipe(Effect.provide(TestLayer(exhaustingBinding(3)))),
+  )
+
+  it.effect('happy path with always-allow binding returns the session id', () =>
+    Effect.gen(function* () {
+      const result = yield* ratelimitedCreateSession('1.2.3.4', {
+        initialPrompt: 'hi',
+      })
+      expect(result.sessionId).toMatch(/^rs_/)
+      expect(result.eventStreamUrl).toBe(`/session/${result.sessionId}/stream`)
+    }).pipe(Effect.provide(TestLayer(alwaysAllow))),
+  )
+})

--- a/src/shared/runtime/main.ts
+++ b/src/shared/runtime/main.ts
@@ -9,6 +9,7 @@
  *   - `BraveSearch`          via `BraveLive` (Brave Search API)
  *   - `Context7`             via `Context7Live` (public Context7 v1)
  *   - `UrlFetcher`           via `UrlFetcherLive` (timeout + size guard)
+ *   - `RateLimiter`          via `RateLimiterLive` (CF rate-limit bindings)
  *
  * Per-request services (`EventStreamUrlBuilder`, `SessionContext`) are
  * NOT in here — those are provided fresh at the request boundary, where
@@ -41,6 +42,11 @@ import {
   UrlFetcherLive,
   type UrlFetcherLiveOptions,
 } from '~/shared/infra/url-fetcher/client'
+import {
+  RateLimiter,
+  RateLimiterLive,
+  type RateLimitBinding,
+} from '~/shared/infra/ratelimit/client'
 import { EventStreamUrlBuilder } from '~/shared/research/session'
 
 export interface MainLiveOptions {
@@ -49,12 +55,38 @@ export interface MainLiveOptions {
   readonly brave?: BraveLiveOptions
   readonly context7?: Context7LiveOptions
   readonly urlFetcher?: UrlFetcherLiveOptions
+  /**
+   * Worker-edge rate-limit bindings. Optional: only the worker entry
+   * (server.ts / server-fns) provides them. The Durable Object lives
+   * behind the worker boundary, so its RateLimiter is a no-op (every
+   * inbound DO request has already passed the worker gate).
+   */
+  readonly rateLimit?: {
+    readonly sessionCreate: RateLimitBinding
+    readonly answerSubmit: RateLimitBinding
+    /**
+     * Window length in seconds. Mirrors the `period` configured on the
+     * underlying `RateLimit()` bindings in `alchemy.run.ts`. Used as the
+     * `Retry-After` value the worker sends on 429s.
+     */
+    readonly periodSeconds: number
+  }
+}
+
+const allowAlways: RateLimitBinding = {
+  limit: async () => ({ success: true }),
 }
 
 export const MainLive = (
   options: MainLiveOptions,
 ): Layer.Layer<
-  Ids | Groq | ResearchRepository | BraveSearch | Context7 | UrlFetcher,
+  | Ids
+  | Groq
+  | ResearchRepository
+  | BraveSearch
+  | Context7
+  | UrlFetcher
+  | RateLimiter,
   GroqAuthError
 > =>
   Layer.mergeAll(
@@ -64,6 +96,13 @@ export const MainLive = (
     BraveLive(options.brave ?? { apiKey: undefined }),
     Context7Live(options.context7 ?? {}),
     UrlFetcherLive(options.urlFetcher ?? {}),
+    RateLimiterLive(
+      options.rateLimit ?? {
+        sessionCreate: allowAlways,
+        answerSubmit: allowAlways,
+        periodSeconds: 60,
+      },
+    ),
   )
 
 /**


### PR DESCRIPTION
## Summary

- **Edge rate limiting** for session creation (10/min) and answer submission (60/min) via Cloudflare Workers RateLimit API to protect against brute-force research DoS
- **Session access control** via `session_owner` cookie and URL-keyed access; sessions scoped to cookie holder only
- **Session viewing** at `/session/$id` — reopening a session URL resumes the live stream with the same session ID and event history
- **Research tools** implemented: `webSearch` (Brave), `searchLibraryDocs` (Context7), and `readUrl` for grounding agent recommendations
- **Error resilience** in agent loop: retries on transient failures, repairs malformed tool calls, graceful fallback when external APIs fail
- **SSE replay** on EventSource reconnect — `Last-Event-ID` header re-emits missed events so rejoining a session catches up
- **Database schema** expanded: `research_steps.event` stores encoded `AgentEvent` JSON for replay; `research_sessions.owner_id` enforces access boundaries
- **UX improvements** for rate limiting: friendly "try again in N seconds" messages instead of raw error tags

## Testing

- Unit tests for auth (cookie signing, header extraction, access checks): `src/shared/auth/*.test.ts` ✓
- Unit tests for research tools (Brave, Context7, URL fetching): `src/shared/infra/{brave,context7,url-fetcher}/client.test.ts` ✓
- Unit tests for rate limiting client: `src/shared/infra/ratelimit/client.test.ts` ✓
- Integration tests for session access control and ownership: `src/shared/auth/access.integration.test.ts` ✓
- Integration tests for research tool integration: `src/shared/agent/research-tools.integration.test.ts` ✓
- Integration tests for session rate limiting: `src/shared/research/session.ratelimit.integration.test.ts` ✓
- Agent loop tests covering retries and error handling: `src/shared/agent/loop.test.ts` ✓
- Research orchestrator and replay tests: `src/shared/research/orchestrator.test.ts`, `replay.integration.test.ts` ✓
- Manual testing of `/session/$id` access and SSE reconnect: **Not run** (requires local dev setup with secrets)
- Rate limit feedback in UI (error messages): verified in `question-card.tsx` ✓